### PR TITLE
[BE] 구글 소셜로그인 구현

### DIFF
--- a/chatty-be/src/main/java/com/chatty/chatty/auth/controller/oauth/OAuthController.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/auth/controller/oauth/OAuthController.java
@@ -5,6 +5,7 @@ import com.chatty.chatty.auth.controller.oauth.dto.SocialLoginRequest;
 import com.chatty.chatty.auth.entity.Provider;
 import com.chatty.chatty.auth.service.oauth.OAuthService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -12,13 +13,14 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 public class OAuthController {
 
     private final OAuthService oAuthService;
 
-    @PostMapping("/oauth/{provider}/login")
+    @PostMapping("/oauth/{provider}/signIn")
     public ResponseEntity<TokenResponse> signIn(
             @RequestBody SocialLoginRequest request,
             @PathVariable String provider

--- a/chatty-be/src/main/java/com/chatty/chatty/auth/controller/oauth/dto/GoogleAccessTokenRequest.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/auth/controller/oauth/dto/GoogleAccessTokenRequest.java
@@ -1,0 +1,2 @@
+package com.chatty.chatty.auth.controller.oauth.dto;public record GoogleAccessTokenRequest() {
+}

--- a/chatty-be/src/main/java/com/chatty/chatty/auth/controller/oauth/dto/GoogleAccessTokenRequest.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/auth/controller/oauth/dto/GoogleAccessTokenRequest.java
@@ -1,2 +1,14 @@
-package com.chatty.chatty.auth.controller.oauth.dto;public record GoogleAccessTokenRequest() {
+package com.chatty.chatty.auth.controller.oauth.dto;
+
+import lombok.Builder;
+
+@Builder
+public record GoogleAccessTokenRequest(
+        String code,
+        String client_id,
+        String client_secret,
+        String redirect_uri,
+        String grant_type
+) {
+
 }

--- a/chatty-be/src/main/java/com/chatty/chatty/auth/controller/oauth/dto/GoogleLoginResponse.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/auth/controller/oauth/dto/GoogleLoginResponse.java
@@ -1,0 +1,2 @@
+package com.chatty.chatty.auth.controller.oauth.dto;public class GoogleLoginResponse {
+}

--- a/chatty-be/src/main/java/com/chatty/chatty/auth/controller/oauth/dto/GoogleLoginResponse.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/auth/controller/oauth/dto/GoogleLoginResponse.java
@@ -1,2 +1,16 @@
-package com.chatty.chatty.auth.controller.oauth.dto;public class GoogleLoginResponse {
+package com.chatty.chatty.auth.controller.oauth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class GoogleLoginResponse {
+
+    private String email;
+    private String picture;
 }

--- a/chatty-be/src/main/java/com/chatty/chatty/auth/controller/oauth/google/GoogleAuthApi.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/auth/controller/oauth/google/GoogleAuthApi.java
@@ -1,0 +1,2 @@
+package com.chatty.chatty.auth.controller.oauth.google;public interface GoogleAuthApi {
+}

--- a/chatty-be/src/main/java/com/chatty/chatty/auth/controller/oauth/google/GoogleAuthApi.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/auth/controller/oauth/google/GoogleAuthApi.java
@@ -1,2 +1,16 @@
-package com.chatty.chatty.auth.controller.oauth.google;public interface GoogleAuthApi {
+package com.chatty.chatty.auth.controller.oauth.google;
+
+import com.chatty.chatty.auth.config.FeignConfiguration;
+import com.chatty.chatty.auth.controller.oauth.dto.GoogleAccessTokenRequest;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@FeignClient(value = "googleAuth", url = "https://oauth2.googleapis.com/", configuration = FeignConfiguration.class)
+public interface GoogleAuthApi {
+
+    @PostMapping("/token")
+    ResponseEntity<String> getAccessToken(@RequestBody GoogleAccessTokenRequest requestDto);
+
 }

--- a/chatty-be/src/main/java/com/chatty/chatty/auth/controller/oauth/google/GoogleUserApi.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/auth/controller/oauth/google/GoogleUserApi.java
@@ -1,2 +1,14 @@
-package com.chatty.chatty.auth.controller.oauth.google;public interface GoogleUserApi {
+package com.chatty.chatty.auth.controller.oauth.google;
+
+import com.chatty.chatty.auth.config.FeignConfiguration;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(value = "googleUser", url = "https://www.googleapis.com", configuration = {FeignConfiguration.class})
+public interface GoogleUserApi {
+
+    @GetMapping("/userinfo/v2/me")
+    ResponseEntity<String> getUserInfo(@RequestParam("access_token") String accessToken);
 }

--- a/chatty-be/src/main/java/com/chatty/chatty/auth/controller/oauth/google/GoogleUserApi.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/auth/controller/oauth/google/GoogleUserApi.java
@@ -1,0 +1,2 @@
+package com.chatty.chatty.auth.controller.oauth.google;public interface GoogleUserApi {
+}

--- a/chatty-be/src/main/java/com/chatty/chatty/auth/service/oauth/GoogleLoginService.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/auth/service/oauth/GoogleLoginService.java
@@ -1,0 +1,2 @@
+package com.chatty.chatty.auth.service.oauth;public class GoogleLoginService {
+}

--- a/chatty-be/src/main/java/com/chatty/chatty/auth/service/oauth/GoogleLoginService.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/auth/service/oauth/GoogleLoginService.java
@@ -1,2 +1,74 @@
-package com.chatty.chatty.auth.service.oauth;public class GoogleLoginService {
+package com.chatty.chatty.auth.service.oauth;
+
+import com.chatty.chatty.auth.controller.oauth.dto.GoogleLoginResponse;
+import com.chatty.chatty.auth.controller.oauth.dto.SocialAuthResponse;
+import com.chatty.chatty.auth.controller.oauth.dto.SocialUserResponse;
+import com.chatty.chatty.auth.controller.oauth.google.GoogleAuthApi;
+import com.chatty.chatty.auth.controller.oauth.google.GoogleUserApi;
+import com.chatty.chatty.auth.entity.Provider;
+import com.chatty.chatty.auth.support.GsonLocalDateTimeAdapter;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import com.chatty.chatty.auth.controller.oauth.dto.GoogleAccessTokenRequest;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class GoogleLoginService implements SocialLoginService {
+
+    private final GoogleAuthApi googleAuthApi;
+    private final GoogleUserApi googleUserApi;
+
+    @Value("${social.client.google.client-id}")
+    private String googleAppKey;
+    @Value("${social.client.google.client-secret}")
+    private String googleAppSecret;
+    @Value("${social.client.google.redirect-uri}")
+    private String googleRedirectUri;
+    @Value("${social.client.google.grant_type}")
+    private String googleGrantType;
+
+    @Override
+    public Provider getServiceName() {
+        return Provider.GOOGLE;
+    }
+
+    @Override
+    public SocialAuthResponse getAccessToken(String authorizationCode) {
+        ResponseEntity<?> response = googleAuthApi.getAccessToken(
+                GoogleAccessTokenRequest.builder()
+                        .code(authorizationCode)
+                        .client_id(googleAppKey)
+                        .client_secret(googleAppSecret)
+                        .redirect_uri(googleRedirectUri)
+                        .grant_type(googleGrantType)
+                        .build()
+        );
+        return new Gson()
+                .fromJson(
+                        response.getBody().toString(),
+                        SocialAuthResponse.class
+                );
+    }
+
+    @Override
+    public SocialUserResponse getUserInfo(String accessToken) {
+        ResponseEntity<?> response = googleUserApi.getUserInfo(accessToken);
+        String jsonString = response.getBody().toString();
+        Gson gson = new GsonBuilder()
+                .setPrettyPrinting()
+                .registerTypeAdapter(LocalDateTime.class, new GsonLocalDateTimeAdapter())
+                .create();
+        GoogleLoginResponse googleLoginResponse = gson.fromJson(jsonString, GoogleLoginResponse.class);
+        return SocialUserResponse.builder()
+                .email(googleLoginResponse.getEmail())
+                .profileImage(googleLoginResponse.getPicture())
+                .build();
+    }
 }

--- a/chatty-be/src/main/java/com/chatty/chatty/auth/service/oauth/OAuthService.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/auth/service/oauth/OAuthService.java
@@ -30,12 +30,8 @@ public class OAuthService {
     @Transactional
     public TokenResponse signIn(SocialLoginRequest request, Provider provider) {
         SocialLoginService loginService = getLoginService(provider);
-        log.info("request.code() : {}", request.code());
-        log.info("loginService.getServiceName() : {}", loginService.getServiceName());
         SocialAuthResponse socialAuthResponse = loginService.getAccessToken(request.code());
         SocialUserResponse socialUserResponse = loginService.getUserInfo(socialAuthResponse.getAccess_token());
-        log.info("socialUserResponse : {}", socialUserResponse.email());
-        log.info("socialUserResponse : {}", socialUserResponse.profileImage());
 
         Optional<User> optionalUser = userRepository.findByEmail(socialUserResponse.email());
         User user;
@@ -51,8 +47,6 @@ public class OAuthService {
         } else {
             user = optionalUser.get();
         }
-        log.info("user.getEmail() : {}", user.getEmail());
-        log.info("user.getProfileImage() : {}", user.getProfileImage());
 
         String accessToken = jwtUtil.createAccessToken(user);
         String refreshToken = jwtUtil.createRefreshToken(user);

--- a/chatty-be/src/main/resources/application-local.yml
+++ b/chatty-be/src/main/resources/application-local.yml
@@ -20,3 +20,8 @@ social:
       client-secret: KtXGlrkvmLgT8KbvgVzmbvXt15bXXdp6
       redirect-uri: http://localhost:3000/sign-in/kakao/callback
       grant_type: authorization_code
+    google:
+      client-id: 536185302907-cs7293um69ca55b9p2c0k6339ir37cjn.apps.googleusercontent.com
+      client-secret: g
+      redirect-uri: http://localhost:3000/sign-in/google/callback
+      grant_type: authorization_code


### PR DESCRIPTION
## 개요

- #53 

## 작업사항

- 구글 소셜 로그인 구현

## 참고
- 추후 소셜 로그인은 refreshToken은 보내지 않도록 수정하겠습니다.
- 일반 로그인과의 통일성을 위해 기존
`http://localhost:8080/api/oauth/google/login` 에서 `http://localhost:8080/api/oauth/google/signIn`
으로 변경되었습니다.

### 스크린샷(선택)
<img width="1104" alt="스크린샷 2024-03-18 17 14 13" src="https://github.com/Team-WeQuiz/wequiz/assets/90228925/0c0bcadf-ca4c-4ee8-8086-48d64bc2715c">
<img width="1012" alt="스크린샷 2024-03-18 17 15 53" src="https://github.com/Team-WeQuiz/wequiz/assets/90228925/e74365ad-79fd-4b9f-9e1b-fa165052a8e9">
