### PR TITLE
[BE] refresh token 재발급 api

### DIFF
--- a/chatty-be/src/main/java/com/chatty/chatty/auth/controller/AuthController.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/auth/controller/AuthController.java
@@ -1,5 +1,6 @@
 package com.chatty.chatty.auth.controller;
 
+import com.chatty.chatty.auth.controller.dto.RefreshTokenRequest;
 import com.chatty.chatty.auth.controller.dto.SignInRequest;
 import com.chatty.chatty.auth.controller.dto.SignInResponse;
 import com.chatty.chatty.auth.controller.dto.SignUpRequest;
@@ -30,5 +31,10 @@ public class AuthController {
     @PostMapping("/signIn")
     public ResponseEntity<SignInResponse> signIn(@RequestBody SignInRequest request) {
         return ResponseEntity.status(HttpStatus.OK).body(authService.signIn(request));
+    }
+
+    @PostMapping("/refresh")
+    public ResponseEntity<SignUpResponse> refresh(@RequestBody RefreshTokenRequest request) {
+        return ResponseEntity.status(HttpStatus.OK).body(authService.refresh(request));
     }
 }

--- a/chatty-be/src/main/java/com/chatty/chatty/auth/controller/AuthController.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/auth/controller/AuthController.java
@@ -1,8 +1,9 @@
 package com.chatty.chatty.auth.controller;
 
 import com.chatty.chatty.auth.controller.dto.SignInRequest;
+import com.chatty.chatty.auth.controller.dto.SignInResponse;
 import com.chatty.chatty.auth.controller.dto.SignUpRequest;
-import com.chatty.chatty.auth.controller.dto.TokenResponse;
+import com.chatty.chatty.auth.controller.dto.SignUpResponse;
 import com.chatty.chatty.auth.service.AuthService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -22,15 +23,12 @@ public class AuthController {
     }
 
     @PostMapping("/signUp")
-    public ResponseEntity<TokenResponse> signUp(@RequestBody SignUpRequest request) {
-        if (authService.findByEmail(request.email()).isPresent()) {
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
-        }
+    public ResponseEntity<SignUpResponse> signUp(@RequestBody SignUpRequest request) {
         return ResponseEntity.status(HttpStatus.CREATED).body(authService.signUp(request));
     }
 
     @PostMapping("/signIn")
-    public ResponseEntity<TokenResponse> signIn(@RequestBody SignInRequest request) {
+    public ResponseEntity<SignInResponse> signIn(@RequestBody SignInRequest request) {
         return ResponseEntity.status(HttpStatus.OK).body(authService.signIn(request));
     }
 }

--- a/chatty-be/src/main/java/com/chatty/chatty/auth/controller/dto/RefreshTokenRequest.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/auth/controller/dto/RefreshTokenRequest.java
@@ -1,6 +1,9 @@
 package com.chatty.chatty.auth.controller.dto;
 
-public record RefreshTokenResponse(
+import lombok.Builder;
+
+@Builder
+public record RefreshTokenRequest(
         String refreshToken
 ) {
 

--- a/chatty-be/src/main/java/com/chatty/chatty/auth/controller/dto/RefreshTokenResponse.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/auth/controller/dto/RefreshTokenResponse.java
@@ -1,0 +1,7 @@
+package com.chatty.chatty.auth.controller.dto;
+
+public record RefreshTokenResponse(
+        String refreshToken
+) {
+
+}

--- a/chatty-be/src/main/java/com/chatty/chatty/auth/controller/dto/SignInResponse.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/auth/controller/dto/SignInResponse.java
@@ -3,9 +3,8 @@ package com.chatty.chatty.auth.controller.dto;
 import lombok.Builder;
 
 @Builder
-public record TokenResponse(
-        String accessToken,
-        String refreshToken
+public record SignInResponse(
+        String accessToken
 ) {
 
 }

--- a/chatty-be/src/main/java/com/chatty/chatty/auth/controller/dto/SignUpResponse.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/auth/controller/dto/SignUpResponse.java
@@ -1,0 +1,11 @@
+package com.chatty.chatty.auth.controller.dto;
+
+import lombok.Builder;
+
+@Builder
+public record SignUpResponse(
+        String accessToken,
+        String refreshToken
+) {
+
+}

--- a/chatty-be/src/main/java/com/chatty/chatty/auth/controller/oauth/OAuthController.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/auth/controller/oauth/OAuthController.java
@@ -1,7 +1,7 @@
 package com.chatty.chatty.auth.controller.oauth;
 
-import com.chatty.chatty.auth.controller.dto.TokenResponse;
 import com.chatty.chatty.auth.controller.oauth.dto.SocialLoginRequest;
+import com.chatty.chatty.auth.controller.dto.SignInResponse;
 import com.chatty.chatty.auth.entity.Provider;
 import com.chatty.chatty.auth.service.oauth.OAuthService;
 import lombok.RequiredArgsConstructor;
@@ -21,7 +21,7 @@ public class OAuthController {
     private final OAuthService oAuthService;
 
     @PostMapping("/oauth/{provider}/signIn")
-    public ResponseEntity<TokenResponse> signIn(
+    public ResponseEntity<SignInResponse> signIn(
             @RequestBody SocialLoginRequest request,
             @PathVariable String provider
     ) {

--- a/chatty-be/src/main/java/com/chatty/chatty/auth/exception/AuthExceptionType.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/auth/exception/AuthExceptionType.java
@@ -15,6 +15,7 @@ public enum AuthExceptionType implements ExceptionType {
     UNSUPPORTED_TOKEN(Status.BAD_REQUEST, 1008, "지원하지 않는 토큰입니다"),
     INVALID_SIGNATURE(Status.BAD_REQUEST, 1009, "잘못된 서명입니다"),
     UNSUPPORTED_LOGIN_PROVIDER(Status.BAD_REQUEST, 1010, "지원하지 않는 로그인 제공자입니다"),
+    INVALID_EMAIL(Status.BAD_REQUEST, 1011, "이미 사용중인 이메일입니다"),
     ;
 
     private final Status status;

--- a/chatty-be/src/main/java/com/chatty/chatty/auth/interceptor/LoginInterceptor.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/auth/interceptor/LoginInterceptor.java
@@ -25,7 +25,7 @@ public class LoginInterceptor implements HandlerInterceptor {
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
         String token = AuthenticationExtractor.extract(request)
                 .orElseThrow(() -> new AuthException(UNAUTHORIZED));
-        Long userId = jwtUtil.extract(token);
+        Long userId = jwtUtil.getUserIdFromToken(token);
         log.info("userId: {}", userId);
         authenticationContext.setAuthentication(userId);
         return true;

--- a/chatty-be/src/main/java/com/chatty/chatty/auth/jwt/JwtUtil.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/auth/jwt/JwtUtil.java
@@ -8,7 +8,6 @@ import static com.chatty.chatty.auth.exception.AuthExceptionType.SIGNATURE_NOT_F
 import static com.chatty.chatty.auth.exception.AuthExceptionType.UNSUPPORTED_TOKEN;
 
 import com.chatty.chatty.auth.exception.AuthException;
-import com.chatty.chatty.auth.exception.AuthExceptionType;
 import com.chatty.chatty.user.entity.User;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
@@ -60,7 +59,7 @@ public class JwtUtil {
                 .compact();
     }
 
-    public boolean isValidRefreshToken(String refreshToken) {
+    public boolean isRefreshTokenValid(String refreshToken) {
         if (isTokenExpired(refreshToken)) {
             return false;
         }

--- a/chatty-be/src/main/java/com/chatty/chatty/auth/jwt/JwtUtil.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/auth/jwt/JwtUtil.java
@@ -75,7 +75,7 @@ public class JwtUtil {
         return getClaimFromToken(token).getExpiration().before(new Date());
     }
 
-    public Long extract(String token) {
+    public Long getUserIdFromToken(String token) {
         try {
             return getClaimFromToken(token).get("id", Long.class);
         } catch (SecurityException e) {

--- a/chatty-be/src/main/java/com/chatty/chatty/auth/repository/RefreshTokenRepository.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/auth/repository/RefreshTokenRepository.java
@@ -7,4 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
 
     Optional<RefreshToken> findByUserId(Long userId);
+
+    void deleteByUserId(Long userId);
 }

--- a/chatty-be/src/main/java/com/chatty/chatty/auth/service/oauth/OAuthService.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/auth/service/oauth/OAuthService.java
@@ -2,9 +2,9 @@ package com.chatty.chatty.auth.service.oauth;
 
 import static com.chatty.chatty.auth.exception.AuthExceptionType.UNSUPPORTED_LOGIN_PROVIDER;
 
-import com.chatty.chatty.auth.controller.dto.TokenResponse;
 import com.chatty.chatty.auth.controller.oauth.dto.SocialAuthResponse;
 import com.chatty.chatty.auth.controller.oauth.dto.SocialLoginRequest;
+import com.chatty.chatty.auth.controller.dto.SignInResponse;
 import com.chatty.chatty.auth.controller.oauth.dto.SocialUserResponse;
 import com.chatty.chatty.auth.entity.Provider;
 import com.chatty.chatty.auth.exception.AuthException;
@@ -28,7 +28,7 @@ public class OAuthService {
     private final JwtUtil jwtUtil;
 
     @Transactional
-    public TokenResponse signIn(SocialLoginRequest request, Provider provider) {
+    public SignInResponse signIn(SocialLoginRequest request, Provider provider) {
         SocialLoginService loginService = getLoginService(provider);
         SocialAuthResponse socialAuthResponse = loginService.getAccessToken(request.code());
         SocialUserResponse socialUserResponse = loginService.getUserInfo(socialAuthResponse.getAccess_token());
@@ -49,8 +49,7 @@ public class OAuthService {
         }
 
         String accessToken = jwtUtil.createAccessToken(user);
-        String refreshToken = jwtUtil.createRefreshToken(user);
-        return new TokenResponse(accessToken, refreshToken);
+        return new SignInResponse(accessToken);
     }
 
     private SocialLoginService getLoginService(Provider provider) {

--- a/chatty-be/src/main/resources/application-local.yml
+++ b/chatty-be/src/main/resources/application-local.yml
@@ -21,7 +21,7 @@ social:
       redirect-uri: http://localhost:3000/sign-in/kakao/callback
       grant_type: authorization_code
     google:
-      client-id: 536185302907-cs7293um69ca55b9p2c0k6339ir37cjn.apps.googleusercontent.com
-      client-secret: g
+      client-id: 98146529486-md3ri8vfvupsgokf1bup6smaeuj1bbuo.apps.googleusercontent.com
+      client-secret: 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
       redirect-uri: http://localhost:3000/sign-in/google/callback
       grant_type: authorization_code


### PR DESCRIPTION
## 개요

- #105 

## 작업사항

- google 소셜 로그인 client secret 오타 수정
- 일반 로그인 및 소셜 로그인의 경우 refreshToken 없이 AccessToken만 발급
- refresh token 재발급 api `/api/auth/refresh`

### 스크린샷(선택)
> 일반 로그인
<img width="800" alt="스크린샷 2024-03-20 02 32 50" src="https://github.com/Team-WeQuiz/wequiz/assets/90228925/f0b43fbb-ee8e-432d-b39f-f1353b4b96da">


> refresh token 재발급
<img width="800" alt="스크린샷 2024-03-20 02 31 40" src="https://github.com/Team-WeQuiz/wequiz/assets/90228925/e5f739b9-24ef-40bb-892b-43137f90c541">
