### PR TITLE
[BE] 대기실 채팅 기능

### DIFF
--- a/chatty-be/src/main/java/com/chatty/chatty/config/WebSocketConfig.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/config/WebSocketConfig.java
@@ -12,14 +12,14 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
-        registry.addEndpoint("/ws-connection")
+        registry.addEndpoint("/ws")
                 .setAllowedOriginPatterns("*")
                 .withSockJS();
     }
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
-        registry.enableSimpleBroker("/subscribe");
-        registry.setApplicationDestinationPrefixes("/publish");
+        registry.enableSimpleBroker("/sub");
+        registry.setApplicationDestinationPrefixes("/pub");
     }
 }

--- a/chatty-be/src/main/java/com/chatty/chatty/quizroom/controller/SocketController.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/quizroom/controller/SocketController.java
@@ -22,7 +22,8 @@ public class SocketController {
     @SendTo("/sub/rooms/{roomId}")
     public ChatResponse chat(@DestinationVariable Long roomId, ChatRequest request) {
         return ChatResponse.builder()
-                .roomId(roomId)
+                .chatType(request.getChatType())
+                .roomId(request.getRoomId())
                 .userId(request.getUserId())
                 .message(request.getMessage())
                 .time(LocalDateTime.now())

--- a/chatty-be/src/main/java/com/chatty/chatty/quizroom/controller/SocketController.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/quizroom/controller/SocketController.java
@@ -8,7 +8,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.SendTo;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -16,7 +15,6 @@ import org.springframework.web.bind.annotation.RestController;
 public class SocketController {
 
     private final SocketService socketService;
-    private final SimpMessagingTemplate simpMessagingTemplate;
 
     @MessageMapping("/rooms/{roomId}/chat")
     @SendTo("/sub/rooms/{roomId}")

--- a/chatty-be/src/main/java/com/chatty/chatty/quizroom/controller/SocketController.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/quizroom/controller/SocketController.java
@@ -1,0 +1,31 @@
+package com.chatty.chatty.quizroom.controller;
+
+import com.chatty.chatty.quizroom.controller.dto.ChatRequest;
+import com.chatty.chatty.quizroom.controller.dto.ChatResponse;
+import com.chatty.chatty.quizroom.service.SocketService;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class SocketController {
+
+    private final SocketService socketService;
+    private final SimpMessagingTemplate simpMessagingTemplate;
+
+    @MessageMapping("/rooms/{roomId}/chat")
+    @SendTo("/sub/rooms/{roomId}")
+    public ChatResponse chat(@DestinationVariable Long roomId, ChatRequest request) {
+        return ChatResponse.builder()
+                .roomId(roomId)
+                .userId(request.getUserId())
+                .message(request.getMessage())
+                .time(LocalDateTime.now())
+                .build();
+    }
+}

--- a/chatty-be/src/main/java/com/chatty/chatty/quizroom/controller/dto/ChatRequest.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/quizroom/controller/dto/ChatRequest.java
@@ -11,10 +11,6 @@ import lombok.NoArgsConstructor;
 @Getter
 public class ChatRequest {
 
-    public enum ChatType {
-        TEXT, EMOJI
-    }
-
     private ChatType chatType;
 
     private Long roomId;

--- a/chatty-be/src/main/java/com/chatty/chatty/quizroom/controller/dto/ChatRequest.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/quizroom/controller/dto/ChatRequest.java
@@ -1,0 +1,26 @@
+package com.chatty.chatty.quizroom.controller.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class ChatRequest {
+
+    public enum ChatType {
+        TEXT, EMOJI
+    }
+
+    private ChatType chatType;
+
+    private Long roomId;
+
+    private Long userId;
+
+    private String message;
+
+}

--- a/chatty-be/src/main/java/com/chatty/chatty/quizroom/controller/dto/ChatResponse.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/quizroom/controller/dto/ChatResponse.java
@@ -1,18 +1,25 @@
 package com.chatty.chatty.quizroom.controller.dto;
 
 import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Builder
-public record ChatResponse(
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class ChatResponse {
 
-        Long roomId,
+    private ChatType chatType;
 
-        Long userId,
+    private Long roomId;
 
-        String message,
+    private Long userId;
 
-        LocalDateTime time
+    private String message;
 
-) {
+    private LocalDateTime time;
+
 }

--- a/chatty-be/src/main/java/com/chatty/chatty/quizroom/controller/dto/ChatResponse.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/quizroom/controller/dto/ChatResponse.java
@@ -1,0 +1,18 @@
+package com.chatty.chatty.quizroom.controller.dto;
+
+import java.time.LocalDateTime;
+import lombok.Builder;
+
+@Builder
+public record ChatResponse(
+
+        Long roomId,
+
+        Long userId,
+
+        String message,
+
+        LocalDateTime time
+
+) {
+}

--- a/chatty-be/src/main/java/com/chatty/chatty/quizroom/controller/dto/ChatType.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/quizroom/controller/dto/ChatType.java
@@ -1,0 +1,7 @@
+package com.chatty.chatty.quizroom.controller.dto;
+
+public enum ChatType {
+
+    TEXT,
+    EMOJI
+}

--- a/chatty-be/src/main/java/com/chatty/chatty/quizroom/entity/QuizRoom.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/quizroom/entity/QuizRoom.java
@@ -14,17 +14,21 @@ import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Entity
 @Getter
-@Setter
 @Builder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EqualsAndHashCode(of = "id", callSuper = false)
 @Table(name = "quiz_rooms")
 public class QuizRoom extends BaseEntity {
+
+    public enum Status {
+        READY,
+        STARTED,
+        FINISHED
+    }
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/chatty-be/src/main/java/com/chatty/chatty/quizroom/entity/QuizRoom.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/quizroom/entity/QuizRoom.java
@@ -23,13 +23,7 @@ import lombok.NoArgsConstructor;
 @EqualsAndHashCode(of = "id", callSuper = false)
 @Table(name = "quiz_rooms")
 public class QuizRoom extends BaseEntity {
-
-    public enum Status {
-        READY,
-        STARTED,
-        FINISHED
-    }
-
+    
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "room_id")

--- a/chatty-be/src/main/java/com/chatty/chatty/quizroom/entity/Status.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/quizroom/entity/Status.java
@@ -1,0 +1,8 @@
+package com.chatty.chatty.quizroom.entity;
+
+public enum Status {
+
+    READY,
+    STARTED,
+    FINISHED
+}

--- a/chatty-be/src/main/java/com/chatty/chatty/quizroom/entity/Status.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/quizroom/entity/Status.java
@@ -1,8 +1,0 @@
-package com.chatty.chatty.quizroom.entity;
-
-public enum Status {
-
-    READY,
-    STARTED,
-    FINISHED
-}

--- a/chatty-be/src/main/java/com/chatty/chatty/quizroom/service/SocketService.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/quizroom/service/SocketService.java
@@ -1,4 +1,7 @@
 package com.chatty.chatty.quizroom.service;
 
+import org.springframework.stereotype.Service;
+
+@Service
 public class SocketService {
 }

--- a/chatty-be/src/main/java/com/chatty/chatty/quizroom/service/SocketService.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/quizroom/service/SocketService.java
@@ -1,0 +1,4 @@
+package com.chatty.chatty.quizroom.service;
+
+public class SocketService {
+}


### PR DESCRIPTION
## 개요

- #119 

## 작업사항

- 클라이언트에서 소켓 연결할 때 ```/ws```로 핸드쉐이크 하고 
- 플레이어 입장 시 ```/sub/rooms/{roomId}``` 로 구독하고 ```/pub/rooms/{roomId}/chat``` 로 메세지 보내주심 됩니다!!
- 이모지랑 텍스트 채팅을 구분했습니다. 이모지는 ```chatType: EMOJI```, 텍스트는 ```chatType: TEXT```로 설정했습니다
- 끝나면 휘발되는 일회성 채팅이라 부하가 많지 않을 거 같아 Spring 내부 메세지 브로커를 쓰려 했으나, 요청이 많을 시 서버가 과부하될 수 있다는 점 때문에 메세지 브로커로 redis 도입을 고려 중입니다

### 스크린샷(선택)
![image](https://github.com/Team-WeQuiz/wequiz/assets/66215132/76a27803-eaf2-4935-b414-dcdc6f166732)
![image](https://github.com/Team-WeQuiz/wequiz/assets/66215132/7ff20af0-186c-4a40-bec4-a9e9642cbf33)
APIC에서 테스트를 진행했습니다.
두 개의 창을 띄워 같은 url을 구독하고 메세지를 전송했을 때 두 창 모두 메세지를 받는 것을 확인했습니다
다만, SockJS는 보안 이슈로 Origin 설정에 와일드카드를 허용하지 않는데, APIC에서는 Origin을 알 수 없어 EPIC 테스트 시에는 ```withSockJS();```를 주석처리 해야 합니다!