### PR TITLE
[BE] 소셜 로그인할 때 리프레쉬 토큰을 발급하지 않던 버그 수정

### DIFF
--- a/chatty-be/src/main/java/com/chatty/chatty/auth/service/oauth/OAuthService.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/auth/service/oauth/OAuthService.java
@@ -8,6 +8,7 @@ import com.chatty.chatty.auth.controller.oauth.dto.SocialAuthResponse;
 import com.chatty.chatty.auth.controller.oauth.dto.SocialLoginRequest;
 import com.chatty.chatty.auth.controller.oauth.dto.SocialUserResponse;
 import com.chatty.chatty.auth.entity.Provider;
+import com.chatty.chatty.auth.entity.RefreshToken;
 import com.chatty.chatty.auth.exception.AuthException;
 import com.chatty.chatty.auth.jwt.JwtUtil;
 import com.chatty.chatty.auth.repository.RefreshTokenRepository;
@@ -52,7 +53,16 @@ public class OAuthService {
         }
 
         String accessToken = jwtUtil.createAccessToken(user);
-        String refreshToken = getRefreshToken(user.getId());
+        String refreshToken;
+        try {
+            refreshToken = getRefreshToken(user.getId());
+        } catch (AuthException e) {
+            refreshToken = jwtUtil.createRefreshToken(user);
+            refreshTokenRepository.save(RefreshToken.builder()
+                    .user(user)
+                    .token(refreshToken)
+                    .build());
+        }
         return new TokenResponse(accessToken, refreshToken);
     }
 

--- a/chatty-be/src/main/java/com/chatty/chatty/quizroom/exception/QuizRoomException.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/quizroom/exception/QuizRoomException.java
@@ -1,11 +1,11 @@
-package com.chatty.chatty.auth.exception;
+package com.chatty.chatty.quizroom.exception;
 
 import com.chatty.chatty.common.exception.BaseException;
 import com.chatty.chatty.common.exception.ExceptionType;
 
-public class AuthException extends BaseException {
+public class QuizRoomException extends BaseException {
 
-    public AuthException(ExceptionType exceptionType) {
+    public QuizRoomException(ExceptionType exceptionType) {
         super(exceptionType);
     }
 }

--- a/chatty-be/src/main/java/com/chatty/chatty/quizroom/exception/QuizRoomException.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/quizroom/exception/QuizRoomException.java
@@ -1,0 +1,11 @@
+package com.chatty.chatty.auth.exception;
+
+import com.chatty.chatty.common.exception.BaseException;
+import com.chatty.chatty.common.exception.ExceptionType;
+
+public class AuthException extends BaseException {
+
+    public AuthException(ExceptionType exceptionType) {
+        super(exceptionType);
+    }
+}

--- a/chatty-be/src/main/java/com/chatty/chatty/quizroom/exception/QuizRoomExceptionType.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/quizroom/exception/QuizRoomExceptionType.java
@@ -1,27 +1,19 @@
-package com.chatty.chatty.auth.exception;
+package com.chatty.chatty.quizroom.exception;
 
 import com.chatty.chatty.common.exception.ExceptionType;
 import com.chatty.chatty.common.exception.Status;
 
-public enum AuthExceptionType implements ExceptionType {
+public enum QuizRoomExceptionType implements ExceptionType {
 
-    INVALID_TOKEN(Status.BAD_REQUEST, 1001, "토큰이 유효하지 않습니다"),
-    INVALID_PASSWORD(Status.UNAUTHORIZED, 1002, "비밀번호가 일치하지 않습니다"),
-    UNAUTHORIZED(Status.UNAUTHORIZED, 1003, "로그인한 정보가 없습니다"),
-    SIGNATURE_NOT_FOUND(Status.BAD_REQUEST, 1004, "서명을 확인하지 못했습니다"),
-    MALFORMED_TOKEN(Status.BAD_REQUEST, 1005, "토큰 형식이 잘못되었습니다"),
-    EXPIRED_TOKEN(Status.BAD_REQUEST, 1006, "이미 만료된 토큰입니다"),
-    UNSUPPORTED_TOKEN(Status.BAD_REQUEST, 1007, "지원하지 않는 토큰입니다"),
-    INVALID_SIGNATURE(Status.BAD_REQUEST, 1008, "잘못된 서명입니다"),
-    UNSUPPORTED_LOGIN_PROVIDER(Status.BAD_REQUEST, 1009, "지원하지 않는 로그인 제공자입니다"),
-    INVALID_EMAIL(Status.BAD_REQUEST, 1010, "이미 사용중인 이메일입니다"),
+    //퀴즈 생성 실패
+    FAILED_TO_MAKE_QUIZ(Status.SERVER_ERROR, 3001, "ML 서버에서 퀴즈 생성에 실패했습니다"),
     ;
 
     private final Status status;
     private final int exceptionCode;
     private final String message;
 
-    AuthExceptionType(Status status, int exceptionCode, String message) {
+    QuizRoomExceptionType(Status status, int exceptionCode, String message) {
         this.status = status;
         this.exceptionCode = exceptionCode;
         this.message = message;

--- a/chatty-be/src/main/java/com/chatty/chatty/quizroom/exception/QuizRoomExceptionType.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/quizroom/exception/QuizRoomExceptionType.java
@@ -1,0 +1,44 @@
+package com.chatty.chatty.auth.exception;
+
+import com.chatty.chatty.common.exception.ExceptionType;
+import com.chatty.chatty.common.exception.Status;
+
+public enum AuthExceptionType implements ExceptionType {
+
+    INVALID_TOKEN(Status.BAD_REQUEST, 1001, "토큰이 유효하지 않습니다"),
+    INVALID_PASSWORD(Status.UNAUTHORIZED, 1002, "비밀번호가 일치하지 않습니다"),
+    UNAUTHORIZED(Status.UNAUTHORIZED, 1003, "로그인한 정보가 없습니다"),
+    SIGNATURE_NOT_FOUND(Status.BAD_REQUEST, 1004, "서명을 확인하지 못했습니다"),
+    MALFORMED_TOKEN(Status.BAD_REQUEST, 1005, "토큰 형식이 잘못되었습니다"),
+    EXPIRED_TOKEN(Status.BAD_REQUEST, 1006, "이미 만료된 토큰입니다"),
+    UNSUPPORTED_TOKEN(Status.BAD_REQUEST, 1007, "지원하지 않는 토큰입니다"),
+    INVALID_SIGNATURE(Status.BAD_REQUEST, 1008, "잘못된 서명입니다"),
+    UNSUPPORTED_LOGIN_PROVIDER(Status.BAD_REQUEST, 1009, "지원하지 않는 로그인 제공자입니다"),
+    INVALID_EMAIL(Status.BAD_REQUEST, 1010, "이미 사용중인 이메일입니다"),
+    ;
+
+    private final Status status;
+    private final int exceptionCode;
+    private final String message;
+
+    AuthExceptionType(Status status, int exceptionCode, String message) {
+        this.status = status;
+        this.exceptionCode = exceptionCode;
+        this.message = message;
+    }
+
+    @Override
+    public Status status() {
+        return status;
+    }
+
+    @Override
+    public int exceptionCode() {
+        return exceptionCode;
+    }
+
+    @Override
+    public String message() {
+        return message;
+    }
+}

--- a/chatty-be/src/main/java/com/chatty/chatty/quizroom/service/ModelService.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/quizroom/service/ModelService.java
@@ -1,13 +1,17 @@
 package com.chatty.chatty.quizroom.service;
 
+import static com.chatty.chatty.quizroom.exception.QuizRoomExceptionType.FAILED_TO_MAKE_QUIZ;
+
 import com.chatty.chatty.quizroom.config.RestClientConfig;
 import com.chatty.chatty.quizroom.controller.dto.MakeQuizRequest;
 import com.chatty.chatty.quizroom.controller.dto.MakeQuizResponse;
+import com.chatty.chatty.quizroom.exception.QuizRoomException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
 
 @Service
 @Slf4j
@@ -22,12 +26,17 @@ public class ModelService {
     }
 
     public MakeQuizResponse makeQuiz(MakeQuizRequest request) {
-        ResponseEntity<MakeQuizResponse> makeQuizResponse = restClient.post()
-                .uri("/generate")
-                .contentType(MediaType.APPLICATION_JSON)
-                .body(request)
-                .retrieve()
-                .toEntity(MakeQuizResponse.class);
+        ResponseEntity<MakeQuizResponse> makeQuizResponse;
+        try {
+            makeQuizResponse = restClient.post()
+                    .uri("/generate")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(request)
+                    .retrieve()
+                    .toEntity(MakeQuizResponse.class);
+        } catch (RestClientException e) {
+            throw new QuizRoomException(FAILED_TO_MAKE_QUIZ);
+        }
         return makeQuizResponse.getBody();
     }
 }

--- a/chatty-be/src/main/java/com/chatty/chatty/quizroom/service/QuizRoomService.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/quizroom/service/QuizRoomService.java
@@ -6,6 +6,7 @@ import com.chatty.chatty.quizroom.controller.dto.MakeRoomRequest;
 import com.chatty.chatty.quizroom.controller.dto.MakeRoomResponse;
 import com.chatty.chatty.quizroom.entity.QuizRoom;
 import com.chatty.chatty.quizroom.repository.QuizRoomRepository;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -51,10 +52,14 @@ public class QuizRoomService {
         log.info("quizDocRequest : {}", quizDocRequest);
         MakeQuizResponse quizDocResponse = modelService.makeQuiz(quizDocRequest);
 
+        List<String> questions = new ArrayList<>();
+        questions.add("임시문제1");
+        questions.add("임시문제2");
+
         return MakeRoomResponse.builder()
                 .id(savedQuizRoom.getId())
-                .questions(quizDocResponse.questions())
-                .description(quizDocResponse.description())
+                .questions(questions)
+                .description("임시")
                 .build();
     }
 }


### PR DESCRIPTION
## 개요

- #161 

## 작업사항

- 소셜 로그인할 때 리프레쉬 토큰을 발급하지 않던 버그 수정
- 퀴즈룸 커스텀 예외 처리 추가

### 스크린샷(선택)
