### PR TITLE
[BE] 플레이어 준비 상태 변경 및 퇴장 api

### DIFF
--- a/chatty-be/src/main/java/com/chatty/chatty/quizroom/controller/GameController.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/quizroom/controller/GameController.java
@@ -39,6 +39,12 @@ public class GameController {
         return gameService.joinRoom(roomId, getUserIdFromHeader(headerAccessor));
     }
 
+    @MessageMapping("/rooms/{roomId}/leave")
+    @SendTo("/sub/rooms/{roomId}/status")
+    public PlayersStatusDTO leaveRoom(@DestinationVariable Long roomId, SimpMessageHeaderAccessor headerAccessor) {
+        return gameService.leaveRoom(roomId, getUserIdFromHeader(headerAccessor));
+    }
+
     private Long getUserIdFromHeader(SimpMessageHeaderAccessor headerAccessor) {
         return (Long) Objects.requireNonNull(headerAccessor.getSessionAttributes()).get("userId");
     }

--- a/chatty-be/src/main/java/com/chatty/chatty/quizroom/controller/GameController.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/quizroom/controller/GameController.java
@@ -45,6 +45,12 @@ public class GameController {
         return gameService.leaveRoom(roomId, getUserIdFromHeader(headerAccessor));
     }
 
+    @MessageMapping("/rooms/{roomId}/ready")
+    @SendTo("/sub/rooms/{roomId}/status")
+    public PlayersStatusDTO toggleReady(@DestinationVariable Long roomId, SimpMessageHeaderAccessor headerAccessor) {
+        return gameService.toggleReady(roomId, getUserIdFromHeader(headerAccessor));
+    }
+
     private Long getUserIdFromHeader(SimpMessageHeaderAccessor headerAccessor) {
         return (Long) Objects.requireNonNull(headerAccessor.getSessionAttributes()).get("userId");
     }

--- a/chatty-be/src/main/java/com/chatty/chatty/quizroom/domain/PlayerStatus.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/quizroom/domain/PlayerStatus.java
@@ -1,5 +1,6 @@
 package com.chatty.chatty.quizroom.domain;
 
+import java.util.Objects;
 import lombok.Builder;
 
 @Builder
@@ -15,5 +16,26 @@ public record PlayerStatus(
                 .userId(userId)
                 .isReady(DEFAULT_READY_STATUS)
                 .build();
+    }
+
+    public PlayerStatus toggleReady() {
+        return new PlayerStatus(userId, !isReady);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        PlayerStatus that = (PlayerStatus) o;
+        return Objects.equals(userId, that.userId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(userId);
     }
 }

--- a/chatty-be/src/main/java/com/chatty/chatty/quizroom/domain/PlayersStatus.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/quizroom/domain/PlayersStatus.java
@@ -26,4 +26,15 @@ public record PlayersStatus(
         playerStatusSet.removeIf(playerStatus -> playerStatus.userId().equals(userId));
         return new PlayersStatus(playerStatusSet);
     }
+
+    public PlayersStatus toggleReady(Long userId) {
+        playerStatusSet.stream()
+                .filter(playerStatus -> playerStatus.userId().equals(userId))
+                .findFirst()
+                .ifPresent(playerStatus -> {
+                    playerStatusSet.remove(playerStatus);
+                    playerStatusSet.add(playerStatus.toggleReady());
+                });
+        return new PlayersStatus(playerStatusSet);
+    }
 }

--- a/chatty-be/src/main/java/com/chatty/chatty/quizroom/domain/PlayersStatus.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/quizroom/domain/PlayersStatus.java
@@ -21,4 +21,9 @@ public record PlayersStatus(
         playerStatusSet.add(PlayerStatus.initNewUser(userId));
         return new PlayersStatus(playerStatusSet);
     }
+
+    public PlayersStatus removeUser(Long userId) {
+        playerStatusSet.removeIf(playerStatus -> playerStatus.userId().equals(userId));
+        return new PlayersStatus(playerStatusSet);
+    }
 }

--- a/chatty-be/src/main/java/com/chatty/chatty/quizroom/repository/PlayersStatusRepository.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/quizroom/repository/PlayersStatusRepository.java
@@ -21,7 +21,17 @@ public class PlayersStatusRepository {
 
     public PlayersStatus saveUserToRoom(Long roomId, Long userId) {
         PlayersStatus playersStatus = findByRoomId(roomId).orElse(PlayersStatus.init());
-        playersStatusMap.put(roomId, playersStatus.updateWithNewUser(userId));
+        updateStatus(roomId, playersStatus.updateWithNewUser(userId));
         return playersStatus;
+    }
+
+    public PlayersStatus leaveRoom(Long roomId, Long userId) {
+        PlayersStatus playersStatus = findByRoomId(roomId).orElse(PlayersStatus.init());
+        updateStatus(roomId, playersStatus.removeUser(userId));
+        return playersStatus;
+    }
+
+    private void updateStatus(Long roomId, PlayersStatus playersStatus) {
+        playersStatusMap.put(roomId, playersStatus);
     }
 }

--- a/chatty-be/src/main/java/com/chatty/chatty/quizroom/repository/PlayersStatusRepository.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/quizroom/repository/PlayersStatusRepository.java
@@ -31,6 +31,12 @@ public class PlayersStatusRepository {
         return playersStatus;
     }
 
+    public PlayersStatus toggleReady(Long roomId, Long userId) {
+        PlayersStatus playersStatus = findByRoomId(roomId).orElse(PlayersStatus.init());
+        updateStatus(roomId, playersStatus.toggleReady(userId));
+        return playersStatus;
+    }
+
     private void updateStatus(Long roomId, PlayersStatus playersStatus) {
         playersStatusMap.put(roomId, playersStatus);
     }

--- a/chatty-be/src/main/java/com/chatty/chatty/quizroom/service/GameService.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/quizroom/service/GameService.java
@@ -14,6 +14,15 @@ public class GameService {
 
     public PlayersStatusDTO joinRoom(Long roomId, Long userId) {
         PlayersStatus playersStatus = playersStatusRepository.saveUserToRoom(roomId, userId);
+        return buildDTO(roomId, playersStatus);
+    }
+
+    public PlayersStatusDTO leaveRoom(Long roomId, Long userId) {
+        PlayersStatus playersStatus = playersStatusRepository.leaveRoom(roomId, userId);
+        return buildDTO(roomId, playersStatus);
+    }
+
+    private PlayersStatusDTO buildDTO(Long roomId, PlayersStatus playersStatus) {
         return PlayersStatusDTO.builder()
                 .roomId(roomId)
                 .playerStatuses(playersStatus.playerStatusSet())

--- a/chatty-be/src/main/java/com/chatty/chatty/quizroom/service/GameService.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/quizroom/service/GameService.java
@@ -22,6 +22,11 @@ public class GameService {
         return buildDTO(roomId, playersStatus);
     }
 
+    public PlayersStatusDTO toggleReady(Long roomId, Long userId) {
+        PlayersStatus playersStatus = playersStatusRepository.toggleReady(roomId, userId);
+        return buildDTO(roomId, playersStatus);
+    }
+
     private PlayersStatusDTO buildDTO(Long roomId, PlayersStatus playersStatus) {
         return PlayersStatusDTO.builder()
                 .roomId(roomId)

--- a/chatty-be/src/test/java/com/chatty/chatty/user/service/UserServiceTest.java
+++ b/chatty-be/src/test/java/com/chatty/chatty/user/service/UserServiceTest.java
@@ -1,4 +1,0 @@
-import static org.junit.jupiter.api.Assertions.*;
-class UserServiceTest {
-  
-}


### PR DESCRIPTION
## 개요

- #134 

## 작업사항

- `PlayerStatus`의 `eqauls()` 와  `hashCode()` 를 오버라이딩 하여 `userId` 만으로 객체를 구분할 수 있도록 변경하였습니다.
- 플레이어가 퀴즈룸에서 퇴장하는 api를 구현하였습니다.
- 플레이어가 퀴즈룸에서 준비상태를 변경하는 api를 구현하였습니다.

### 스크린샷(선택)
> 플레이어 퇴장
<img width="1150" alt="스크린샷 2024-04-05 10 35 52" src="https://github.com/Team-WeQuiz/wequiz/assets/90228925/98469815-b7d0-48dc-97ba-6f83cdcc96f3">

### 

> 플레이어 준비상태 변경
<img width="1158" alt="스크린샷 2024-04-05 10 36 13" src="https://github.com/Team-WeQuiz/wequiz/assets/90228925/f6151e16-c747-4472-8b40-6cda6f1eaf44">
