### PR TITLE
[BE] stomp 에러 핸들링 및 채팅에서 user를 header를 통해 받도록 수정

### DIFF
--- a/chatty-be/src/main/java/com/chatty/chatty/auth/jwt/JwtUtil.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/auth/jwt/JwtUtil.java
@@ -19,7 +19,6 @@ import io.jsonwebtoken.UnsupportedJwtException;
 import io.jsonwebtoken.security.SignatureException;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
-import java.util.Optional;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 import lombok.extern.slf4j.Slf4j;
@@ -93,13 +92,6 @@ public class JwtUtil {
             throw new AuthException(INVALID_SIGNATURE);
         }
     }
-
-    public Optional<Long> getUserIdFromTokenWithoutException(String token) {
-        return Optional.ofNullable(token)
-                .map(this::getClaimFromToken)
-                .map(claims -> claims.get("id", Long.class));
-    }
-
 
     private Claims getClaimFromToken(String token) {
         return Jwts.parser()

--- a/chatty-be/src/main/java/com/chatty/chatty/config/WebSocketConfig.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/config/WebSocketConfig.java
@@ -1,6 +1,7 @@
 package com.chatty.chatty.config;
 
 import com.chatty.chatty.config.interceptor.StompHandler;
+import com.chatty.chatty.exception.StompExceptionHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.ChannelRegistration;
@@ -15,12 +16,14 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     private final StompHandler stompHandler;
+    private final StompExceptionHandler stompExceptionHandler;
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/ws")
                 .setAllowedOriginPatterns("*");
         // TODO .withSockJS();
+        registry.setErrorHandler(stompExceptionHandler);
     }
 
     @Override

--- a/chatty-be/src/main/java/com/chatty/chatty/config/interceptor/StompHandler.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/config/interceptor/StompHandler.java
@@ -5,8 +5,10 @@ import com.chatty.chatty.auth.support.AuthenticationExtractor;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.messaging.simp.stomp.StompCommand;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.messaging.support.ChannelInterceptor;
@@ -23,12 +25,10 @@ public class StompHandler implements ChannelInterceptor {
     public Message<?> preSend(Message<?> message, MessageChannel channel) {
         StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
         if (StompCommand.CONNECT.equals(accessor.getCommand())) {
-            String token = AuthenticationExtractor.extract(accessor.getFirstNativeHeader("Authorization"))
-                    .orElse(null);
-            Optional<Long> userId = jwtUtil.getUserIdFromTokenWithoutException(token);
-            userId.ifPresent(id -> accessor.getSessionAttributes().put("userId", id));
+            String token = AuthenticationExtractor.extract(accessor.getFirstNativeHeader("Authorization")).get();
+            Long userId = jwtUtil.getUserIdFromToken(token);
+            accessor.getSessionAttributes().put("userId", userId);
         }
-
         return message;
     }
 }

--- a/chatty-be/src/main/java/com/chatty/chatty/exception/StompExceptionHandler.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/exception/StompExceptionHandler.java
@@ -1,0 +1,52 @@
+package com.chatty.chatty.exception;
+
+import com.chatty.chatty.common.exception.BaseException;
+import java.nio.charset.StandardCharsets;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.web.socket.messaging.StompSubProtocolErrorHandler;
+
+@Configuration
+@RequiredArgsConstructor
+@Slf4j
+public class StompExceptionHandler extends StompSubProtocolErrorHandler {
+
+    private static final String BASE_ERROR_MESSAGE = "INTERNAL_SERVER_ERROR";
+
+    @Override
+    public Message<byte[]> handleClientMessageProcessingError(Message<byte[]> clientMessage, Throwable ex) {
+        Throwable cause = ex.getCause();
+        if (cause instanceof BaseException) {
+            log.error(cause.getMessage(), cause);
+            return errorMessage((BaseException) cause);
+        }
+        return errorMessage();
+    }
+
+    private Message<byte[]> errorMessage(BaseException ex) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.ERROR);
+        accessor.setLeaveMutable(true);
+        log.error(ex.getMessage(), ex);
+        String errorMessage = ex.getExceptionType().message();
+
+        return MessageBuilder.createMessage(
+                errorMessage.getBytes(StandardCharsets.UTF_8),
+                accessor.getMessageHeaders()
+        );
+    }
+
+    private Message<byte[]> errorMessage() {
+        StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.ERROR);
+        accessor.setLeaveMutable(true);
+
+        return MessageBuilder.createMessage(
+                StompExceptionHandler.BASE_ERROR_MESSAGE.getBytes(StandardCharsets.UTF_8),
+                accessor.getMessageHeaders()
+        );
+    }
+}

--- a/chatty-be/src/main/java/com/chatty/chatty/quizroom/controller/GameController.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/quizroom/controller/GameController.java
@@ -8,10 +8,14 @@ import java.time.LocalDateTime;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -49,6 +53,12 @@ public class GameController {
     @SendTo("/sub/rooms/{roomId}/status")
     public PlayersStatusDTO toggleReady(@DestinationVariable Long roomId, SimpMessageHeaderAccessor headerAccessor) {
         return gameService.toggleReady(roomId, getUserIdFromHeader(headerAccessor));
+    }
+
+    @DeleteMapping("/rooms/{roomId}/end")
+    public ResponseEntity<Void> endGame(@PathVariable Long roomId) {
+        gameService.endGame(roomId);
+        return ResponseEntity.status(HttpStatus.OK).build();
     }
 
     private Long getUserIdFromHeader(SimpMessageHeaderAccessor headerAccessor) {

--- a/chatty-be/src/main/java/com/chatty/chatty/quizroom/controller/GameController.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/quizroom/controller/GameController.java
@@ -27,11 +27,15 @@ public class GameController {
 
     @MessageMapping("/rooms/{roomId}/chat")
     @SendTo("/sub/rooms/{roomId}/chat")
-    public ChatResponse chat(@DestinationVariable Long roomId, ChatRequest request) {
+    public ChatResponse chat(
+            @DestinationVariable Long roomId,
+            SimpMessageHeaderAccessor headerAccessor,
+            ChatRequest request
+    ) {
         return ChatResponse.builder()
                 .chatType(request.chatType())
                 .roomId(request.roomId())
-                .userId(request.userId())
+                .userId(getUserIdFromHeader(headerAccessor))
                 .message(request.message())
                 .time(LocalDateTime.now())
                 .build();

--- a/chatty-be/src/main/java/com/chatty/chatty/quizroom/controller/dto/ChatRequest.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/quizroom/controller/dto/ChatRequest.java
@@ -5,8 +5,6 @@ public record ChatRequest(
 
         Long roomId,
 
-        Long userId,
-
         String message
 ) {
 

--- a/chatty-be/src/main/java/com/chatty/chatty/quizroom/repository/PlayersStatusRepository.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/quizroom/repository/PlayersStatusRepository.java
@@ -21,20 +21,26 @@ public class PlayersStatusRepository {
 
     public PlayersStatus saveUserToRoom(Long roomId, Long userId) {
         PlayersStatus playersStatus = findByRoomId(roomId).orElse(PlayersStatus.init());
+        log.info("saveUserToRoom: {}", playersStatus);
+        log.info("roomId: {}", roomId);
         updateStatus(roomId, playersStatus.updateWithNewUser(userId));
         return playersStatus;
     }
 
     public PlayersStatus leaveRoom(Long roomId, Long userId) {
-        PlayersStatus playersStatus = findByRoomId(roomId).orElse(PlayersStatus.init());
+        PlayersStatus playersStatus = findByRoomId(roomId).get();
         updateStatus(roomId, playersStatus.removeUser(userId));
         return playersStatus;
     }
 
     public PlayersStatus toggleReady(Long roomId, Long userId) {
-        PlayersStatus playersStatus = findByRoomId(roomId).orElse(PlayersStatus.init());
+        PlayersStatus playersStatus = findByRoomId(roomId).get();
         updateStatus(roomId, playersStatus.toggleReady(userId));
         return playersStatus;
+    }
+
+    public void clear(Long roomId) {
+        playersStatusMap.remove(roomId);
     }
 
     private void updateStatus(Long roomId, PlayersStatus playersStatus) {

--- a/chatty-be/src/main/java/com/chatty/chatty/quizroom/service/GameService.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/quizroom/service/GameService.java
@@ -4,17 +4,22 @@ import com.chatty.chatty.quizroom.controller.dto.PlayersStatusDTO;
 import com.chatty.chatty.quizroom.domain.PlayersStatus;
 import com.chatty.chatty.quizroom.repository.PlayersStatusRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class GameService {
 
     private final PlayersStatusRepository playersStatusRepository;
 
     public PlayersStatusDTO joinRoom(Long roomId, Long userId) {
+        log.info("joinRoom: roomId: {}, userId: {}", roomId, userId);
         PlayersStatus playersStatus = playersStatusRepository.saveUserToRoom(roomId, userId);
-        return buildDTO(roomId, playersStatus);
+        PlayersStatusDTO playersStatusDTO = buildDTO(roomId, playersStatus);
+        log.info("joinRoom: {}", playersStatusDTO);
+        return playersStatusDTO;
     }
 
     public PlayersStatusDTO leaveRoom(Long roomId, Long userId) {
@@ -25,6 +30,10 @@ public class GameService {
     public PlayersStatusDTO toggleReady(Long roomId, Long userId) {
         PlayersStatus playersStatus = playersStatusRepository.toggleReady(roomId, userId);
         return buildDTO(roomId, playersStatus);
+    }
+
+    public void endGame(Long roomId) {
+        playersStatusRepository.clear(roomId);
     }
 
     private PlayersStatusDTO buildDTO(Long roomId, PlayersStatus playersStatus) {


### PR DESCRIPTION
## 개요

- #198 

## 작업사항

- stomp 에러 핸들링을 통해 연결 전 jwt 검증 작업 -> user 에 null이 들어갈 수 없음
- 채팅 request dto에서 userId를 제거 -> header 에 jwt를 보내줘야함
-  (중요!) 방이 터지거나 종료될 때(본 게임 시작 될 때) `/api/rooms/{roomId}/end` 에 `delete` 요청을 보내주어 메모리에 저장되어 있던 유저들 상태 정보 삭제 @KRimwoo @ryanbae94 (반환메세지 따로 없고 성공 시 200ok)

### 비고
- 소켓 통신 전 jwt 검증을 제외한 나머지 에러는 따로 처리하지 않을 예정입니다. 멘토님 말씀대로 클라이언트와 서버 간 메세지 포맷을 잘 맞춰야 할 것 같아요

### 스크린샷(선택)
<img width="514" alt="스크린샷 2024-04-09 14 37 33" src="https://github.com/Team-WeQuiz/wequiz/assets/90228925/90849907-e2bf-4f1f-9205-96d96a122d24">
<img width="1270" alt="스크린샷 2024-04-09 14 40 55" src="https://github.com/Team-WeQuiz/wequiz/assets/90228925/8a5d03b9-5e1d-46a8-9be7-faae463fac47">
