### PR TITLE
[ML]  description 먼저 nosql에 올리고 id리턴하도록 수정

### DIFF
--- a/model/app/app.py
+++ b/model/app/app.py
@@ -16,6 +16,7 @@ app = FastAPI()
 class GenerateRequest(BaseModel):
     id: int
     timestamp: str
+    user_id: int
     numOfQuiz: int
     type: str
     files: List[str]
@@ -66,43 +67,16 @@ def generate(generate_request: GenerateRequest):
     summarizer = Summarizer(OPENAI_API_KEY)
     try:
         summary = summarizer.summarize(split_docs)
-        yield summary
     except Exception as e:
         log('error', f'Failed to Summarize PDF: {str(e)}', AWS_ACCESS_KEY)
         raise e
-
-    #### generate quiz ####
-    prob_generator = ProbGenerator(split_docs, OPENAI_API_KEY)
-    #### NotImplemented keyword part ####
-    keywords = ["원핫인코딩", "의미기반 언어모델", "사전학습", "전처리", "미세조정"]
-    if len(keywords) != generate_request.numOfQuiz:
-        raise Exception('키워드가 충분히 생성되지 않았습니다.')
-    questions = []
-    #####################################
-    for idx, keyword in enumerate(keywords):
-        try:
-            generated_prob = prob_generator.generate(generate_request.type, keyword, idx+1)
-            questions.append(generated_prob)
-        except Exception as e:
-            log('error', f'Failed to Generate Quiz {idx}-{keyword}: {str(e)}', AWS_ACCESS_KEY)
-            raise e
-
+    
     # DynamoDB에 삽입할 데이터 구성
     data = {
         "id": {"N": str(generate_request.id)},  # id를 문자열로 변환하여 저장
         "timestamp": {"S": generate_request.timestamp},  # 변환하지 않고 그대로 사용
-        "questions": {"L": [
-            {
-                "M": {
-                    "id": {"S": str(question["id"])},
-                    "question_number": {"N": str(question["question_number"])},
-                    "type": {"S": question["type"]},
-                    "question": {"S": question["question"]},
-                    "options": {"L": [{"S": option} for option in question["options"]]},
-                    "answer": {"S": question["answer"]}
-                }
-            } for question in questions  # Assuming `questions` is a list of question objects
-        ]},
+        "user_id": {"N": str(generate_request.user_id)},
+        "questions": {"L": []},
         "description": {"S": summary}
     }
 
@@ -114,13 +88,65 @@ def generate(generate_request: GenerateRequest):
         )
 
         res = {
-            "id": generate_request.id
+            "id": generate_request.id,
+            "summary": summary
         }
 
         yield res
     except Exception as e:
-        log('error', f'Failed to push quiz to dynamodb: {str(e)}', AWS_ACCESS_KEY)
+        log('error', f'Failed to push summary to dynamodb: {str(e)}', AWS_ACCESS_KEY)
         raise e
+
+
+    #### generate quiz ####
+    prob_generator = ProbGenerator(split_docs, OPENAI_API_KEY)
+    #### NotImplemented keyword part ####
+    keywords = ["원핫인코딩", "의미기반 언어모델", "사전학습", "전처리", "미세조정"]
+    if len(keywords) != generate_request.numOfQuiz:
+        raise Exception('키워드가 충분히 생성되지 않았습니다.')
+    questions = []
+    #####################################
+    for idx, keyword in enumerate(keywords):
+        try:
+            # DynamoDB에서 아이템을 읽어옵니다.
+            response = dynamodb.get_item(
+                TableName=TABLE_NAME,
+                Key={
+                    'id': {'N': str(generate_request.id)},  # Partition key
+                    'timestamp': {'S': generate_request.timestamp}  # Sort key
+                }
+            )
+            # 읽어온 아이템에 새로운 질문을 추가합니다.
+            item = response['Item']
+            questions = item.get('questions', {'L': []})['L']  # 기존의 questions 리스트를 가져옵니다.
+
+            question = prob_generator.generate(generate_request.type, keyword, idx+1)  # 새 문제를 생성합니다.
+            new_question = {
+                "M": {
+                    "id": {"S": str(question["id"])},
+                    "question_number": {"N": str(question["question_number"])},
+                    "type": {"S": question["type"]},
+                    "question": {"S": question["question"]},
+                    "options": {"L": [{"S": option} for option in question["options"]]},
+                    "answer": {"S": question["answer"]}
+                }
+            }
+            questions.append(new_question)  # 기존의 문제리스트에 새 문제를 추가합니다.
+
+            # 변경된 아이템을 DynamoDB에 다시 업데이트합니다.
+            response = dynamodb.update_item(
+                TableName=TABLE_NAME,
+                Key={
+                    'id': {'N': str(generate_request.id)},  # Partition key
+                    'timestamp': {'S': generate_request.timestamp}  # Sort key
+                },
+                UpdateExpression='SET questions = :val',  # 업데이트할 표현식
+                ExpressionAttributeValues={':val': {'L': questions}}  # 업데이트할 값
+            )
+
+        except Exception as e:
+            log('error', f'Failed to Generate Quiz {idx}-{keyword}: {str(e)}', AWS_ACCESS_KEY)
+            raise e
 
 
 


### PR DESCRIPTION
## 개요

- #201 

## 작업사항

- description 먼저 dynamodb에 올리고 문서 id, description을 백에 반환합니다.
- 이어서 문제를 생성하면서 dynamodb에 계속 업데이트합니다.

### 스크린샷(선택)
![image](https://github.com/Team-WeQuiz/wequiz/assets/66217855/b7ef7c1f-94e7-4cf5-9bea-c401587e8095)
- 문제 생성 요청하면 dynamodb 문서 id와 description을 함께 반환합니다.
- 백에서는 description 사용을 위해 dynamodb에 접근할 필요가 없습니다.
- 이후 문제 업데이트가 되었는지 확인하거나 문제를 가져올때 접근하면 됩니다.

![image](https://github.com/Team-WeQuiz/wequiz/assets/66217855/147abe38-cc89-4ba5-b4df-2404551ba51f)
- dynamodb에는 위와 같이 쌓고 있습니다.