### PR TITLE
[BE] 로비 퀴즈룸 페이지네이션 및 소켓을 통해 퀴즈룸 리스트 전달

### DIFF
--- a/chatty-be/src/main/java/com/chatty/chatty/player/repository/PlayersStatusRepository.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/player/repository/PlayersStatusRepository.java
@@ -43,6 +43,12 @@ public class PlayersStatusRepository {
         playersStatusMap.remove(roomId);
     }
 
+    public Integer countPlayers(Long roomId) {
+        return findByRoomId(roomId)
+                .map(status -> status.playerStatusSet().size())
+                .orElse(0);
+    }
+
     private void updateStatus(Long roomId, PlayersStatus playersStatus) {
         playersStatusMap.put(roomId, playersStatus);
     }

--- a/chatty-be/src/main/java/com/chatty/chatty/quizroom/controller/QuizRoomController.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/quizroom/controller/QuizRoomController.java
@@ -8,8 +8,20 @@ import com.chatty.chatty.quizroom.controller.dto.RoomQuizResponse;
 import com.chatty.chatty.quizroom.entity.QuizRoom;
 import com.chatty.chatty.quizroom.service.QuizRoomService;
 import java.util.List;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.messaging.simp.annotation.SendToUser;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -18,23 +30,24 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/rooms")
+@Slf4j
 public class QuizRoomController {
 
     private final QuizRoomService quizRoomService;
 
-    public QuizRoomController(QuizRoomService quizRoomService) {
-        this.quizRoomService = quizRoomService;
-    }
-
-    @GetMapping
-    public ResponseEntity<List<QuizRoom>> getRooms() {
-        return ResponseEntity.status(HttpStatus.OK).body(quizRoomService.getRooms());
-    }
-
     @GetMapping("/{roomId}")
     public ResponseEntity<RoomDetailResponse> getRoomDetail(@PathVariable Long roomId) {
         return ResponseEntity.status(HttpStatus.OK).body(quizRoomService.getRoomDetail(roomId));
+    }
+
+    @MessageMapping("/rooms")
+    @SendToUser("/queue/rooms")
+    public List<QuizRoom> getRooms(String page) {
+        log.info("connected");
+        log.info("getRooms: {}", page);
+        return quizRoomService.getRooms(Integer.parseInt(page));
     }
 
     @GetMapping("/{roomId}/quiz")
@@ -46,5 +59,9 @@ public class QuizRoomController {
     public ResponseEntity<CreateRoomResponse> createRoom(@ModelAttribute CreateRoomRequest request,
             @AuthUser Long userId) {
         return ResponseEntity.status(HttpStatus.CREATED).body(quizRoomService.createRoom(request, userId));
+    }
+
+    private String getUserIdFromHeader(SimpMessageHeaderAccessor headerAccessor) {
+        return Objects.requireNonNull(headerAccessor.getSessionAttributes()).get("userId").toString();
     }
 }

--- a/chatty-be/src/main/java/com/chatty/chatty/quizroom/controller/QuizRoomController.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/quizroom/controller/QuizRoomController.java
@@ -3,25 +3,19 @@ package com.chatty.chatty.quizroom.controller;
 import com.chatty.chatty.auth.support.AuthUser;
 import com.chatty.chatty.quizroom.controller.dto.CreateRoomRequest;
 import com.chatty.chatty.quizroom.controller.dto.CreateRoomResponse;
+import com.chatty.chatty.quizroom.controller.dto.RoomAbstractResponse;
 import com.chatty.chatty.quizroom.controller.dto.RoomDetailResponse;
 import com.chatty.chatty.quizroom.controller.dto.RoomQuizResponse;
 import com.chatty.chatty.quizroom.entity.QuizRoom;
 import com.chatty.chatty.quizroom.service.QuizRoomService;
 import java.util.List;
-import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.SendTo;
-import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
-import org.springframework.messaging.simp.annotation.SendToUser;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -42,12 +36,10 @@ public class QuizRoomController {
         return ResponseEntity.status(HttpStatus.OK).body(quizRoomService.getRoomDetail(roomId));
     }
 
-    @MessageMapping("/rooms")
-    @SendToUser("/queue/rooms")
-    public List<QuizRoom> getRooms(String page) {
-        log.info("connected");
-        log.info("getRooms: {}", page);
-        return quizRoomService.getRooms(Integer.parseInt(page));
+    @MessageMapping("/rooms?page={page}")
+    @SendTo("/sub/rooms?page={page}")
+    public List<RoomAbstractResponse> getRooms(@DestinationVariable Integer page) {
+        return quizRoomService.getRooms(page);
     }
 
     @GetMapping("/{roomId}/quiz")
@@ -59,9 +51,5 @@ public class QuizRoomController {
     public ResponseEntity<CreateRoomResponse> createRoom(@ModelAttribute CreateRoomRequest request,
             @AuthUser Long userId) {
         return ResponseEntity.status(HttpStatus.CREATED).body(quizRoomService.createRoom(request, userId));
-    }
-
-    private String getUserIdFromHeader(SimpMessageHeaderAccessor headerAccessor) {
-        return Objects.requireNonNull(headerAccessor.getSessionAttributes()).get("userId").toString();
     }
 }

--- a/chatty-be/src/main/java/com/chatty/chatty/quizroom/controller/dto/CreateRoomRequest.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/quizroom/controller/dto/CreateRoomRequest.java
@@ -7,6 +7,8 @@ public record CreateRoomRequest(
 
         String name,
 
+        String description,
+
         Integer numOfQuiz,
 
         Integer timeLimit,

--- a/chatty-be/src/main/java/com/chatty/chatty/quizroom/controller/dto/RoomAbstractResponse.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/quizroom/controller/dto/RoomAbstractResponse.java
@@ -1,0 +1,14 @@
+package com.chatty.chatty.quizroom.controller.dto;
+
+import lombok.Builder;
+
+@Builder
+public record RoomAbstractResponse(
+        Long roomId,
+        String name,
+        String description,
+        Integer currentPlayers,
+        Integer maxPlayers
+) {
+
+}

--- a/chatty-be/src/main/java/com/chatty/chatty/quizroom/entity/QuizRoom.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/quizroom/entity/QuizRoom.java
@@ -33,6 +33,9 @@ public class QuizRoom extends BaseEntity {
     private String name;
 
     @Column(nullable = false)
+    private String description;
+
+    @Column(nullable = false)
     private Integer numOfQuiz;
 
     @Column(nullable = false)

--- a/chatty-be/src/main/java/com/chatty/chatty/quizroom/entity/Status.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/quizroom/entity/Status.java
@@ -1,7 +1,6 @@
 package com.chatty.chatty.quizroom.entity;
 
 public enum Status {
-
     READY,
     STARTED,
     FINISHED

--- a/chatty-be/src/main/java/com/chatty/chatty/quizroom/repository/QuizRoomRepository.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/quizroom/repository/QuizRoomRepository.java
@@ -9,4 +9,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface QuizRoomRepository extends JpaRepository<QuizRoom, Long> {
 
     Page<QuizRoom> findByStatusOrderByCreatedAt(Status status, Pageable pageable);
+
+    Long countByStatus(Status status);
 }

--- a/chatty-be/src/main/java/com/chatty/chatty/quizroom/repository/QuizRoomRepository.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/quizroom/repository/QuizRoomRepository.java
@@ -1,14 +1,12 @@
 package com.chatty.chatty.quizroom.repository;
 
 import com.chatty.chatty.quizroom.entity.QuizRoom;
-import java.util.List;
-import java.util.Optional;
+import com.chatty.chatty.quizroom.entity.Status;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface QuizRoomRepository extends JpaRepository<QuizRoom, Long> {
 
-    List<QuizRoom> findAll();
-
-    Optional<QuizRoom> findById(Long id);
-
+    Page<QuizRoom> findByStatusOrderByCreatedAt(Status status, Pageable pageable);
 }

--- a/chatty-be/src/main/java/com/chatty/chatty/quizroom/service/QuizRoomService.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/quizroom/service/QuizRoomService.java
@@ -21,6 +21,8 @@ import java.util.Arrays;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -33,8 +35,11 @@ public class QuizRoomService {
     private final ModelService modelService;
     private final MinioRepository minioRepository;
 
-    public List<QuizRoom> getRooms() {
-        return quizRoomRepository.findAll();
+    private static final Integer DEFAULT_PAGE_SIZE = 5;
+
+    public List<QuizRoom> getRooms(int page) {
+        PageRequest pageRequest = PageRequest.of(page, DEFAULT_PAGE_SIZE);
+        return quizRoomRepository.findByStatusOrderByCreatedAt(Status.READY, pageRequest).getContent();
     }
 
     public RoomDetailResponse getRoomDetail(Long roomId) {
@@ -79,6 +84,7 @@ public class QuizRoomService {
         QuizRoom savedQuizRoom = quizRoomRepository.save(
                 QuizRoom.builder()
                         .name(request.name())
+                        .description(request.description())
                         .numOfQuiz(request.numOfQuiz())
                         .timeLimit(request.timeLimit())
                         .playerLimitNum(request.playerLimitNum())


### PR DESCRIPTION
## 개요

- #155 

## 작업사항

- QuizRoom entity 에 사용자 description 컬럼 추가
- 퀴즈룸 페이지네이션 (5개씩 반환)
- 퀴즈룸 리스트를 소켓으로 변화가 생길 때마다 업데이트
  1. 유저 입장
  2. 유저 퇴장
  3. 퀴즈룸 생성
  4. 퀴즈룸 시작 (추후 추가 예정)
- 퀴즈룸 리스트 소켓 연결
  - `/sub/rooms?page={page}`
  - `/pub/rooms?page={page}`

- 반환 예시
```
[
  {
    "roomId": 26,
    "name": "a",
    "description": "",
    "currentPlayers": 0,
    "maxPlayers": 1
  },
  {
    "roomId": 27,
    "name": "a",
    "description": "",
    "currentPlayers": 0,
    "maxPlayers": 1
  },
  {
    "roomId": 32,
    "name": "a",
    "description": "",
    "currentPlayers": 0,
    "maxPlayers": 1
  },
  {
    "roomId": 33,
    "name": "a",
    "description": "",
    "currentPlayers": 0,
    "maxPlayers": 1
  },
  {
    "roomId": 34,
    "name": "a",
    "description": "",
    "currentPlayers": 0,
    "maxPlayers": 1
  }
]
```
### 스크린샷(선택)
<img width="1570" alt="스크린샷 2024-04-24 02 20 38" src="https://github.com/Team-WeQuiz/wequiz/assets/90228925/bd220234-70e2-47e3-9ffe-11ba23a722eb">
