### PR TITLE
[FE] 대기방에서 모든 준비가 끝나면 게임을 시작하는 로직 구현

### DIFF
--- a/chatty-fe/src/app/(game)/waiting-room/[id]/_components/QuizInfoCard/QuizInfoCard.css.ts
+++ b/chatty-fe/src/app/(game)/waiting-room/[id]/_components/QuizInfoCard/QuizInfoCard.css.ts
@@ -14,7 +14,7 @@ export const header = style({
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
-  marginTop: 63,
+  marginTop: 44,
 });
 
 export const decoIcon = style({
@@ -28,7 +28,7 @@ export const name = style({
   textAlign: 'center',
   backgroundColor: globals.color.blue_main,
   borderRadius: 16,
-  padding: '12px 8px',
+  padding: '12px 8px 12px 24px',
   fontSize: 20,
   fontWeight: 600,
   color: 'white',
@@ -46,7 +46,6 @@ export const description = style({
 
 export const detail = style({
   width: '100%',
-  padding: '14px',
   display: 'flex',
   flexWrap: 'wrap',
   justifyContent: 'space-around',
@@ -56,22 +55,26 @@ export const detail = style({
 export const detailBlock = style({
   display: 'flex',
   width: '100%',
-  maxWidth: 188,
   flexDirection: 'column',
   alignItems: 'center',
   justifyContent: 'center',
   gap: 4,
   padding: '12px 0',
   color: globals.color.black,
+  fontSize: 20,
   fontWeight: 400,
   backgroundColor: globals.color.blue_7,
   borderRadius: 16,
 });
 
-export const detailLabel = style({
-  fontSize: 20,
+export const detailText = style({
+  display: 'flex',
+  alignItems: 'center',
+  lineHeight: 2,
 });
 
-export const detailValue = style({
+export const numText = style({
   fontSize: 26,
+  fontFamily: 'var(--bagel-font)',
+  lineHeight: 0.8,
 });

--- a/chatty-fe/src/app/(game)/waiting-room/[id]/_components/QuizInfoCard/QuizInfoCard.tsx
+++ b/chatty-fe/src/app/(game)/waiting-room/[id]/_components/QuizInfoCard/QuizInfoCard.tsx
@@ -6,17 +6,17 @@ import { useState, useEffect } from 'react';
 type QuizInfo = {
   roomId: number;
   name: string;
-  timeLimit: number;
-  playerLimitNums: number;
+  maxPlayers: number;
   description: string;
+  numOfQuiz: number;
 };
 
 const initialData: QuizInfo = {
   roomId: 0,
   name: '',
-  timeLimit: 0,
-  playerLimitNums: 0,
+  maxPlayers: 0,
   description: '',
+  numOfQuiz: 0,
 };
 
 const QuizInfoCard = ({ roomId }: { roomId: number }) => {
@@ -29,6 +29,13 @@ const QuizInfoCard = ({ roomId }: { roomId: number }) => {
         setData(response);
       } catch (error) {
         console.error('error: ', error);
+        setData({
+          roomId: 0,
+          name: '정보를 불러오지 못했습니다.',
+          maxPlayers: 0,
+          description: '',
+          numOfQuiz: 0,
+        });
       }
     };
 
@@ -54,12 +61,12 @@ const QuizInfoCard = ({ roomId }: { roomId: number }) => {
       </div>
       <div className={styles.detail}>
         <div className={styles.detailBlock}>
-          <span>인원수</span>
-          <span>{data.playerLimitNums}</span>
-        </div>
-        <div className={styles.detailBlock}>
-          <span>문제 풀이 시간</span>
-          <span>{data.timeLimit}:00</span>
+          <p className={styles.detailText}>
+            최대&nbsp;<span className={styles.numText}>{data.maxPlayers}</span>
+            명의 참여자와&nbsp;
+            <span className={styles.numText}> {data.numOfQuiz}</span>
+            문제를 풉니다
+          </p>
         </div>
       </div>
     </div>

--- a/chatty-fe/src/app/(game)/waiting-room/[id]/_components/ReadyButton/ReadyButton.css.ts
+++ b/chatty-fe/src/app/(game)/waiting-room/[id]/_components/ReadyButton/ReadyButton.css.ts
@@ -1,0 +1,45 @@
+import { style, keyframes } from '@vanilla-extract/css';
+import { globals } from '@/app/globals.css';
+
+export const readyContainer = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 30,
+  alignItems: 'center',
+  justifyContent: 'flex-end',
+  width: '100%',
+});
+
+export const readyStatus = style({
+  fontSize: 30,
+  fontFamily: 'var(--bagel-font)',
+  fontWeight: 400,
+  WebkitTextStrokeColor: globals.color.sub,
+  WebkitTextStrokeWidth: 2,
+  background: `linear-gradient(180deg, #FFF 30%, ${globals.color.sub} 100%)`,
+  backgroundClip: 'text',
+  WebkitBackgroundClip: 'text',
+  WebkitTextFillColor: 'transparent',
+});
+
+const blinkingText = keyframes({
+  '0%': {
+    opacity: 0,
+  },
+  '50%': {
+    opacity: 1,
+  },
+  '100%': {
+    opacity: 0,
+  },
+});
+
+export const buttonText = style({
+  fontSize: 30,
+  fontWeight: 600,
+  lineHeight: '44px',
+});
+
+export const blinking = style({
+  animation: `${blinkingText} 2s infinite`,
+});

--- a/chatty-fe/src/app/(game)/waiting-room/[id]/_components/ReadyButton/ReadyButton.tsx
+++ b/chatty-fe/src/app/(game)/waiting-room/[id]/_components/ReadyButton/ReadyButton.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from 'react';
 import useWaitingStore from '@/app/_store/useWaitingStore';
 import { UserStatus } from '@/app/_types/WaitingStatus';
 import stompClient from '../../_utils/stomp';
+import * as styles from './ReadyButton.css';
 
 const ReadyButton = ({
   roomId,
@@ -30,9 +31,18 @@ const ReadyButton = ({
   };
 
   return (
-    <GradButton color="secondary" fullWidth rounded onClick={toggleReady}>
-      {isReady ? '시작대기' : '준비하기'}
-    </GradButton>
+    <div className={styles.readyContainer}>
+      {isReady && (
+        <span className={`${styles.readyStatus} ${styles.blinking}`}>
+          waiting
+        </span>
+      )}
+      <GradButton color="secondary" fullWidth rounded onClick={toggleReady}>
+        <span className={`${styles.buttonText} ${!isReady && styles.blinking}`}>
+          {isReady ? '준비취소' : '준비하기'}
+        </span>
+      </GradButton>
+    </div>
   );
 };
 

--- a/chatty-fe/src/app/(game)/waiting-room/[id]/_components/ReadyButton/ReadyButton.tsx
+++ b/chatty-fe/src/app/(game)/waiting-room/[id]/_components/ReadyButton/ReadyButton.tsx
@@ -10,12 +10,15 @@ import * as styles from './ReadyButton.css';
 const ReadyButton = ({
   roomId,
   userId,
+  isQuizReady,
 }: {
   roomId: number;
   userId: number | undefined;
+  isQuizReady: boolean;
 }) => {
-  const { userStatuses } = useWaitingStore();
+  const { userStatuses, allUsersReady } = useWaitingStore();
   const [isReady, setIsReady] = useState<boolean>(false);
+  const [countdown, setCountdown] = useState<number>(3);
 
   useEffect(() => {
     setIsReady(
@@ -30,13 +33,38 @@ const ReadyButton = ({
     });
   };
 
+  useEffect(() => {
+    setCountdown(3);
+    let timer: NodeJS.Timeout | null = null;
+    if (isQuizReady && allUsersReady) {
+      timer = setInterval(() => {
+        setCountdown((prevCount) => {
+          const nextCount = prevCount - 1;
+          if (nextCount === -1) {
+            clearInterval(timer!)
+            // 페이지 이동 시키기
+          }
+          return nextCount;
+        });
+      }, 1000);
+    }
+    return () => {
+      if (timer) clearInterval(timer);
+    };
+  }, [isQuizReady, allUsersReady]);
+
   return (
     <div className={styles.readyContainer}>
-      {isReady && (
-        <span className={`${styles.readyStatus} ${styles.blinking}`}>
-          waiting
-        </span>
-      )}
+      {isReady &&
+        (isQuizReady && allUsersReady ? (
+          <span className={styles.readyStatus}>
+            {countdown > 0 ? countdown : '퀴즈 시작 !'}
+          </span>
+        ) : (
+          <span className={`${styles.readyStatus} ${styles.blinking}`}>
+            waiting
+          </span>
+        ))}
       <GradButton color="secondary" fullWidth rounded onClick={toggleReady}>
         <span className={`${styles.buttonText} ${!isReady && styles.blinking}`}>
           {isReady ? '준비취소' : '준비하기'}

--- a/chatty-fe/src/app/(game)/waiting-room/[id]/_components/UserCard/UserCard.tsx
+++ b/chatty-fe/src/app/(game)/waiting-room/[id]/_components/UserCard/UserCard.tsx
@@ -10,11 +10,14 @@ const UserCard = ({ userStatus }: { userStatus: UserStatus }) => {
   useEffect(() => {
     if (userStatus.message) {
       setShowMessage(true);
-      const timer = setTimeout(() => {
-        setShowMessage(false);
-      }, 5000); // 5초 후 메시지 숨김
+      // 봇 메시지는 숨기지 않음
+      if (userStatus.userId > 0) {
+        const timer = setTimeout(() => {
+          setShowMessage(false);
+        }, 5000); // 5초 후 메시지 숨김
 
-      return () => clearTimeout(timer);
+        return () => clearTimeout(timer);
+      }
     }
   }, [userStatus.message]);
 

--- a/chatty-fe/src/app/(game)/waiting-room/[id]/_components/UserList/UserList.css.ts
+++ b/chatty-fe/src/app/(game)/waiting-room/[id]/_components/UserList/UserList.css.ts
@@ -6,7 +6,7 @@ export const mainContainer = style({
   flexWrap: 'wrap',
   gap: 24,
   width: '100%',
-  minHeight: 792,
+  height: '100%',
   padding: '24px',
   borderRadius: 20,
   backgroundColor: globals.color.blue_6,

--- a/chatty-fe/src/app/(game)/waiting-room/[id]/_components/UserList/UserList.tsx
+++ b/chatty-fe/src/app/(game)/waiting-room/[id]/_components/UserList/UserList.tsx
@@ -1,14 +1,33 @@
 'use client';
 
+import { useEffect, useState } from 'react';
 import UserCard from '../UserCard/UserCard';
 import * as styles from './UserList.css';
 import useWaitingStore from '@/app/_store/useWaitingStore';
+import { UserStatus } from '@/app/_types/WaitingStatus';
 
-const UserList = () => {
+const UserList = ({ isQuizReady }: { isQuizReady: boolean }) => {
   const { userStatuses } = useWaitingStore();
+
+  const [botStatus, setBotStatus] = useState<UserStatus>({
+    userId: -1,
+    isReady: isQuizReady,
+  });
+
+  useEffect(() => {
+    if (isQuizReady) {
+      setBotStatus({
+        userId: -1,
+        isReady: isQuizReady,
+        message: '나도 준비 완료!',
+      });
+    }
+  }, [isQuizReady]);
 
   return (
     <div className={styles.mainContainer}>
+      {/* 문제 생성 확인 봇 */}
+      <UserCard userStatus={botStatus} />
       {userStatuses &&
         userStatuses.map(
           (user) =>

--- a/chatty-fe/src/app/(game)/waiting-room/[id]/page.css.ts
+++ b/chatty-fe/src/app/(game)/waiting-room/[id]/page.css.ts
@@ -5,11 +5,13 @@ export const roomContainer = style({
   width: '100%',
   maxWidth: 1830,
   gap: 30,
+  height: '100%',
 });
 
 export const wideArea = style({
   maxWidth: 1314,
   width: 'calc(73% - 15px)',
+  height: '100%',
   display: 'flex',
   flexDirection: 'column',
   gap: 30,
@@ -20,10 +22,12 @@ export const narrowArea = style({
   width: 'calc(28% - 15px)',
   display: 'flex',
   position: 'relative',
+  height: '100%',
 });
 
 export const userList = style({
   width: '100%',
+  height: 'calc(100% - 80px)',
 });
 
 export const chattingArea = style({
@@ -42,7 +46,6 @@ export const detailArea = style({
 export const buttonWrapper = style({
   position: 'absolute',
   display: 'flex',
-  height: 80,
   width: '100%',
   bottom: 0,
 });

--- a/chatty-fe/src/app/(game)/waiting-room/[id]/page.tsx
+++ b/chatty-fe/src/app/(game)/waiting-room/[id]/page.tsx
@@ -16,6 +16,8 @@ const WaitingRoom = ({ params }: { params: { id: number } }) => {
   const [isConnected, setIsConnected] = useState(false);
   const accessToken = useAuthStore.getState().accessToken;
   const { userStatuses, updateUsers, setMessage } = useWaitingStore();
+  // 퀴즈 생성 완료 체크
+  const [isQuizReady] = useState(false);
 
   const disconnect = () => {
     console.log('Disconnecting from WebSocket');
@@ -98,7 +100,7 @@ const WaitingRoom = ({ params }: { params: { id: number } }) => {
     <div className={styles.roomContainer}>
       <div className={styles.wideArea}>
         <div className={styles.userList}>
-          <UserList />
+          <UserList isQuizReady={isQuizReady} />
         </div>
         <div className={styles.chattingArea}>
           <ChatInput

--- a/chatty-fe/src/app/(game)/waiting-room/[id]/page.tsx
+++ b/chatty-fe/src/app/(game)/waiting-room/[id]/page.tsx
@@ -115,7 +115,11 @@ const WaitingRoom = ({ params }: { params: { id: number } }) => {
           <QuizInfoCard roomId={params.id} />
         </div>
         <div className={styles.buttonWrapper}>
-          <ReadyButton roomId={params.id} userId={userId} />
+          <ReadyButton
+            roomId={params.id}
+            userId={userId}
+            isQuizReady={isQuizReady}
+          />
         </div>
       </div>
     </div>

--- a/chatty-fe/src/app/_api/quiz.ts
+++ b/chatty-fe/src/app/_api/quiz.ts
@@ -2,7 +2,7 @@ import client from './client';
 
 export const getQuizInfo = async (id: number) => {
   try {
-    const response = await client.get(`rooms/${id}/lobby`);
+    const response = await client.get(`rooms/${id}`);
     return response.data;
   } catch (error) {
     console.error('error: ', error);

--- a/chatty-fe/src/app/_store/useWaitingStore.ts
+++ b/chatty-fe/src/app/_store/useWaitingStore.ts
@@ -3,12 +3,14 @@ import { UserStatus } from '@/app/_types/WaitingStatus';
 
 type WaitingStore = {
   userStatuses: UserStatus[];
+  allUsersReady: boolean;
   updateUsers: (userStatuses: UserStatus[]) => void; // 접속 유저 업데이트 함수
   setMessage: (userId: number, message: string) => void; // 메시지 설정 함수
 };
 
 const useWaitingStore = create<WaitingStore>((set) => ({
   userStatuses: [],
+  allUsersReady: false,
   updateUsers: (userStatuses) => {
     set((state) => {
       const existingUserIds = state.userStatuses.map((user) => user.userId);
@@ -33,7 +35,9 @@ const useWaitingStore = create<WaitingStore>((set) => ({
         })
         .filter(Boolean) as UserStatus[];
 
-      return { userStatuses: updatedUserStatuses };
+      const allUsersReady = updatedUserStatuses.every((user) => user.isReady);
+
+      return { userStatuses: updatedUserStatuses, allUsersReady };
     });
   },
   setMessage: (userId, message) => {


### PR DESCRIPTION
## 개요

- #268 

## 작업사항

- 유저 리스트에 userId -1로 퀴즈봇을 추가해 놓았습니다. (추후 문제 준비완료시 문제 봇이 ready되도록 할 예정)
- 문제 준비 + 모든 유저들 준비가 완료되면 3초 카운트를 시작하고 게임이 시작됩니다. 정확히는 4초 소요!
- 후에 "페이지 이동 시키기" 주석 달린 곳에 quiz-room으로 이동하는 코드를 추가하면 됩니다.

### 스크린샷(선택)

![Apr-24-2024 19-54-31](https://github.com/Team-WeQuiz/wequiz/assets/66295173/86e814db-8997-4d41-b6bc-7ac83b269786)

