### PR TITLE
[BE] 통합테스트 피드백 수정

### DIFF
--- a/chatty-be/src/main/java/com/chatty/chatty/common/entity/BaseEntity.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/common/entity/BaseEntity.java
@@ -4,6 +4,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import lombok.AllArgsConstructor;
@@ -19,6 +20,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @NoArgsConstructor
 @AllArgsConstructor
 public abstract class BaseEntity {
+    private static final String DATETIME_FORMAT = "yyyy-MM-dd HH:mm:ss";
 
     @Column(updatable = false, nullable = false)
     @CreatedDate
@@ -30,9 +32,16 @@ public abstract class BaseEntity {
 
     @PrePersist
     public void onPrePersist() {
-        String customLocalDateTimeFormat = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
-        LocalDateTime parsedCreateDate = LocalDateTime.parse(customLocalDateTimeFormat,
-                DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
-        this.createdAt = parsedCreateDate;
+        this.createdAt = getCurrentDateTimeFormatted();
+    }
+
+    @PreUpdate
+    public void onPreUpdate() {
+        this.updatedAt = getCurrentDateTimeFormatted();
+    }
+
+    private LocalDateTime getCurrentDateTimeFormatted() {
+        String formattedDateTime = LocalDateTime.now().format(DateTimeFormatter.ofPattern(DATETIME_FORMAT));
+        return LocalDateTime.parse(formattedDateTime, DateTimeFormatter.ofPattern(DATETIME_FORMAT));
     }
 }

--- a/chatty-be/src/main/java/com/chatty/chatty/game/controller/dto/QuizResponse.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/game/controller/dto/QuizResponse.java
@@ -1,6 +1,6 @@
 package com.chatty.chatty.game.controller.dto;
 
-import com.chatty.chatty.game.controller.dto.dynamodb.Quiz;
+import java.util.List;
 import lombok.Builder;
 
 @Builder
@@ -10,6 +10,12 @@ public record QuizResponse(
 
         Integer currentRound,
 
-        Quiz quiz
+        Integer quizNumber,
+
+        String type,
+
+        String quiz,
+
+        List<String> options
 ) {
 }

--- a/chatty-be/src/main/java/com/chatty/chatty/game/controller/dto/SubmitAnswerRequest.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/game/controller/dto/SubmitAnswerRequest.java
@@ -1,11 +1,7 @@
 package com.chatty.chatty.game.controller.dto;
 
 public record SubmitAnswerRequest(
-        String quizId,
-
         Integer quizNum,
-
-        String answer,
 
         Long playerId,
 

--- a/chatty-be/src/main/java/com/chatty/chatty/game/controller/dto/dynamodb/Quiz.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/game/controller/dto/dynamodb/Quiz.java
@@ -16,6 +16,7 @@ public record Quiz(
 
         List<String> options,
 
+        @JsonProperty("answer")
         String correct
 ) {
 }

--- a/chatty-be/src/main/java/com/chatty/chatty/game/controller/dto/dynamodb/Quiz.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/game/controller/dto/dynamodb/Quiz.java
@@ -16,6 +16,6 @@ public record Quiz(
 
         List<String> options,
 
-        String answer
+        String correct
 ) {
 }

--- a/chatty-be/src/main/java/com/chatty/chatty/game/domain/AnswerData.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/game/domain/AnswerData.java
@@ -13,7 +13,7 @@ public class AnswerData {
     private final Integer majorityNum;
     private final String quizId;
     private final Integer quizNum;
-    private final String answer;
+    private final String correct;
 
     public synchronized SubmitStatus addAnswer(Long playerId, String playerAnswer) {
         playerAnswers.add(Answer.builder()

--- a/chatty-be/src/main/java/com/chatty/chatty/game/domain/QuizData.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/game/domain/QuizData.java
@@ -1,6 +1,7 @@
 package com.chatty.chatty.game.domain;
 
 import com.chatty.chatty.game.controller.dto.dynamodb.Quiz;
+import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import lombok.Builder;
@@ -18,7 +19,16 @@ public class QuizData {
     private final Integer totalRound;
     private Integer currentRound;
 
-    public void increaseCurrentRound() {
+    public Quiz getQuiz() {
+        return quizQueue.peek();
+    }
+
+    public void fillQuiz(List<Quiz> quizzes) {
+        quizQueue.addAll(quizzes);
         this.currentRound++;
+    }
+
+    public Quiz removeQuiz() {
+        return quizQueue.poll();
     }
 }

--- a/chatty-be/src/main/java/com/chatty/chatty/game/repository/AnswerRepository.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/game/repository/AnswerRepository.java
@@ -2,9 +2,8 @@ package com.chatty.chatty.game.repository;
 
 import static com.chatty.chatty.quizroom.exception.QuizRoomExceptionType.ROOM_NOT_FOUND;
 
-import com.chatty.chatty.game.controller.dto.SubmitAnswerRequest;
 import com.chatty.chatty.game.domain.AnswerData;
-import com.chatty.chatty.game.domain.SubmitStatus;
+import com.chatty.chatty.game.domain.QuizData;
 import com.chatty.chatty.quizroom.entity.QuizRoom;
 import com.chatty.chatty.quizroom.exception.QuizRoomException;
 import com.chatty.chatty.quizroom.repository.QuizRoomRepository;
@@ -18,31 +17,28 @@ import org.springframework.stereotype.Repository;
 public class AnswerRepository {
     private static final Map<Long, AnswerData> answerDataMap = new ConcurrentHashMap<>();
     private final QuizRoomRepository quizRoomRepository;
+    private final GameRepository gameRepository;
 
-    public AnswerData getAnswerData(Long roomId, SubmitAnswerRequest request) {
-        return answerDataMap.computeIfAbsent(roomId, id -> initAnswerData(id, request));
+
+    public AnswerData getAnswerData(Long roomId, Integer quizNum) {
+        return answerDataMap.computeIfAbsent(roomId, id -> initAnswerData(id, quizNum));
     }
 
-    private AnswerData initAnswerData(Long roomId, SubmitAnswerRequest request) {
+    private AnswerData initAnswerData(Long roomId, Integer quizNum) {
         QuizRoom quizRoom = quizRoomRepository.findById(roomId)
                 .orElseThrow(() -> new QuizRoomException(ROOM_NOT_FOUND));
+        QuizData quizData = gameRepository.getQuizData(roomId);
 
         return AnswerData.builder()
                 .playerNum(quizRoom.getPlayerNum())
                 .majorityNum((quizRoom.getPlayerNum() + 1) / 2)
-                .quizId(request.quizId())
-                .quizNum(request.quizNum())
-                .answer(request.answer())
+                .quizId(quizData.getQuiz().id())
+                .quizNum(quizNum)
+                .correct(quizData.getQuiz().correct())
                 .build();
     }
 
-    public SubmitStatus addPlayerAnswer(Long roomId, SubmitAnswerRequest request) {
-        AnswerData answerData = getAnswerData(roomId, request);
-
-        return answerData.addAnswer(request.playerId(), request.playerAnswer());
-    }
-
-    public void clearAnswer(Long roomId) {
+    public void clearAnswerData(Long roomId) {
         answerDataMap.remove(roomId);
     }
 }

--- a/chatty-be/src/main/java/com/chatty/chatty/game/repository/dynamodb/DynamoDBRepository.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/game/repository/dynamodb/DynamoDBRepository.java
@@ -5,7 +5,6 @@ import com.amazonaws.services.dynamodbv2.document.DynamoDB;
 import com.amazonaws.services.dynamodbv2.document.Item;
 import com.amazonaws.services.dynamodbv2.document.Table;
 import com.amazonaws.services.dynamodbv2.document.spec.GetItemSpec;
-import com.chatty.chatty.config.AWSKey;
 import java.util.List;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
@@ -23,12 +22,10 @@ public class DynamoDBRepository {
 
     private final AmazonDynamoDB amazonDynamoDB;
     private final DynamoDB dynamoDB;
-    private final AWSKey awsKey;
 
-    public DynamoDBRepository(AmazonDynamoDB amazonDynamoDB, AWSKey awsKey) {
+    public DynamoDBRepository(AmazonDynamoDB amazonDynamoDB) {
         this.amazonDynamoDB = amazonDynamoDB;
         this.dynamoDB = new DynamoDB(amazonDynamoDB);
-        this.awsKey = awsKey;
     }
 
     public String getDescriptionFromDB(String itemId, String timestamp) {

--- a/chatty-be/src/main/java/com/chatty/chatty/game/service/GameService.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/game/service/GameService.java
@@ -68,9 +68,9 @@ public class GameService {
         QuizData quizData = gameRepository.getQuizData(roomId);
         if (quizData.getQuizQueue().isEmpty() && quizData.getCurrentRound() < quizData.getTotalRound()) {
             fillQuiz(quizData);
-            log.info("Fill: QuizData: {}", quizData);
+            log.info("Fill: QuizQueue: {}", quizData.getQuizQueue());
         }
-        log.info("Send: QuizData: {}", quizData);
+        log.info("Send: Quiz: {}", quizData.getQuizQueue().peek());
         return buildQuizResponse(quizData);
     }
 
@@ -82,14 +82,13 @@ public class GameService {
         List<Quiz> currentQuizzes = quizzes.subList(currentRound * QUIZ_SIZE, (currentRound + 1) * QUIZ_SIZE);
         quizData.getQuizQueue().addAll(currentQuizzes);
         quizData.increaseCurrentRound();
-        log.info("filled queue: {}", quizData);
+        log.info("filled queue: {}", quizData.getQuizQueue());
     }
 
     public void removeAndSendQuiz(Long roomId) {
         QuizData quizData = gameRepository.getQuizData(roomId);
         quizData.getQuizQueue().poll();
-        log.info("Remove: QuizData: {}", quizData);
-        sendQuiz(roomId);
+        log.info("Remove: QuizQueue: {}", quizData.getQuizQueue());
     }
 
     /*
@@ -115,7 +114,7 @@ public class GameService {
         return QuizResponse.builder()
                 .quiz(quiz)
                 .totalRound(quizData.getTotalRound())
-                .currentRound(quizData.getCurrentRound() + 1)
+                .currentRound(quizData.getCurrentRound())
                 .build();
     }
 

--- a/chatty-be/src/main/java/com/chatty/chatty/game/service/GameService.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/game/service/GameService.java
@@ -108,10 +108,14 @@ public class GameService {
     }
 
     private QuizResponse buildQuizResponse(QuizData quizData) {
+        Quiz quiz = quizData.getQuiz();
         return QuizResponse.builder()
-                .quiz(quizData.getQuiz())
                 .totalRound(quizData.getTotalRound())
                 .currentRound(quizData.getCurrentRound())
+                .quizNumber(quiz.questionNumber())
+                .type(quiz.type())
+                .quiz(quiz.question())
+                .options(quiz.options())
                 .build();
     }
 

--- a/chatty-be/src/main/java/com/chatty/chatty/game/service/GameService.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/game/service/GameService.java
@@ -64,12 +64,6 @@ public class GameService {
                 .build();
     }
 
-    @Async
-    public void initQuiz(Long roomId) {
-        QuizData quizData = gameRepository.getQuizData(roomId);
-        fillQuiz(quizData);
-    }
-
     public QuizResponse sendQuiz(Long roomId) {
         QuizData quizData = gameRepository.getQuizData(roomId);
         if (quizData.getQuizQueue().isEmpty() && quizData.getCurrentRound() < quizData.getTotalRound()) {


### PR DESCRIPTION
## 개요

- #282 

## 작업사항

- 통합테스트 당시 요청에 따라 모두 제출하면 다음 퀴즈가 자동으로 넘어가도록 작성했었는데 제출 처리 메소드와 퀴즈를 보내는 메소드를 다시 분리하였습니다. **제출 시 submit 경로로 제출하고, 퀴즈가 필요하면 quiz 경로로 요청을 해야합니다.**
- 서버에서 퀴즈를 클라에 넘길 때와 클라에서 서버에 제출 정보를 넘길 때 퀴즈 정답과 퀴즈 id는 포함하지 않도록 DTO를 수정했습니다. 노션 API 명세서를 참고해주세용
- 현재 라운드가 틀린 숫자로 넘어가는 문제를 해결했습니다.
- createdAt 형식 설정한 것과 같이 updatedAt도 설정했습니다.
- QuizData, AnswerData 관련 레포지토리 역할에 따라 메소드 작성하여 코드 리팩토링을 했습니다.
- 로컬 테스트에서 작동 확인했습니다.

### 스크린샷(선택)
