### PR TITLE
[ML] 요약용, 벡터db용 문서 split 분리

### DIFF
--- a/model/app/data/preprocessor.py
+++ b/model/app/data/preprocessor.py
@@ -1,6 +1,6 @@
 import tiktoken, json, re
 from langchain.text_splitter import RecursiveCharacterTextSplitter
-from data.settings import BUCKET_NAME, CHUNK_SIZE, CHUNK_OVERLAP, PARSING_RETRY
+from data.settings import *
 from utils.security import get_minio_access_key
 from data.loader import MinioLoader
 from langchain_community.document_loaders.parsers.pdf import (
@@ -59,24 +59,13 @@ class Parser():
         encoding = tiktoken.get_encoding("cl100k_base")
 
         total_tokens = len(encoding.encode(documents))
-        print(f'예상되는 토큰 수: {total_tokens}')
 
         return total_tokens
     
-    def split_docs(self, documents):
-        
-        total_text = ''
-        page_num = 0
-        for document in documents:
-            total_text += document.page_content
-            page_num += 1
-        
-        print(f'페이지 수: {page_num}')
-
-        total_tokens = self.num_tokens_from_string(total_text)
+    def split_docs(self, total_text, chunk_size, chunk_overlap):
 
         # 결과 출력
-        text_splitter = RecursiveCharacterTextSplitter(chunk_size=CHUNK_SIZE, chunk_overlap=CHUNK_OVERLAP, length_function=len)
+        text_splitter = RecursiveCharacterTextSplitter(chunk_size=chunk_size, chunk_overlap=chunk_overlap, length_function=len)
         splitted_text = text_splitter.split_text(total_text)
         splitted_docs = text_splitter.create_documents(splitted_text)
 
@@ -84,17 +73,29 @@ class Parser():
 
 
     def get_parsed_docs(self, parser, loader, files):
-        docs_list = []
+        summary_docs_list = []
+        vector_docs_list = []
+
         for file in files:
             file_obj = loader.load_file(file)
 
             # PDF 파싱
             documents = parser.lazy_parse(file_obj)
 
-            splitted_docs = self.split_docs(documents)
-            docs_list += splitted_docs
+            # documents를 하나의 text로 병합
+            total_text = ''
+            page_num = 0
+            for document in documents:
+                total_text += document.page_content
+                page_num += 1
+            
+            print(f'페이지 수: {page_num}')
+            print(f'예상되는 토큰 수: {self.num_tokens_from_string(total_text)}')
 
-        return docs_list
+            summary_docs_list += self.split_docs(total_text, SUMMARY_CHUNK_SIZE, SUMMARY_CHUNK_OVERLAP)
+            vector_docs_list += self.split_docs(total_text, VECTOR_CHUNK_SIZE, VECTOR_CHUNK_OVERLAP)
+
+        return summary_docs_list, vector_docs_list
 
 
     # parse files
@@ -108,15 +109,16 @@ class Parser():
             try:
                 # retry 횟수에 따라 파서 선정
                 parser = parsers[retry%3]
-                docs_list = self.get_parsed_docs(parser, loader, minio_files)
+                summary_docs_list, vector_docs_list = self.get_parsed_docs(parser, loader, minio_files)
                 break
             except Exception as e:
                 print(f"An unexpected parsing error occurred: {e}")
                 retry += 1
                 continue
         
-        print(f"총 {len(docs_list)}개의 문서 조각이 준비되었습니다.")
-        return docs_list
+        print(f"요약을 위한 {len(summary_docs_list)}개의 문서 조각이 준비되었습니다.")
+        print(f"벡터화를 위한 {len(vector_docs_list)}개의 문서 조각이 준비되었습니다.")
+        return summary_docs_list, vector_docs_list
 
 
 ##############################################################################

--- a/model/app/data/settings.py
+++ b/model/app/data/settings.py
@@ -1,9 +1,15 @@
 # # preprocessor.py
 BUCKET_NAME = 'wequiz-files'
 PORT = 9010
-CHUNK_SIZE = 2000
-CHUNK_OVERLAP = 400
 PARSING_RETRY = 3
+
+# summary chunk
+SUMMARY_CHUNK_SIZE = 3000
+SUMMARY_CHUNK_OVERLAP = 500
+
+# vector chunk
+VECTOR_CHUNK_SIZE = 1000
+VECTOR_CHUNK_OVERLAP = 200
 
 
 # generator.py

--- a/model/app/model/chain.py
+++ b/model/app/model/chain.py
@@ -33,7 +33,7 @@ class Chain():
         )
 
         relevant_docs = self.retriever.invoke(message)
-        context = " ".join([doc.page_content for doc in relevant_docs])
+        context = " ".join([doc.page_content for doc in relevant_docs])[:200]
         
         return rag_chain.invoke(context)
 


### PR DESCRIPTION
## 개요

- resolves #294 

## 작업사항

- 요약 태스크에서는 문서가 너무 작은 단위로 분리될 필요가 없고 (정확성이 중요한 태스크가 아니기 때문에 / chunk를 작은 단위로 쪼개어 여러개의 chunk를 생성하면 콜 수가 불필요하게 늘어남)
- 벡터 유사도 검색 태스크에서는 문서가 작은 단위로 분리될 필요가 있습니다. (너무 큰 문서는 프롬프트에 넣을 수 없기 때문에)
- 따라서 문서 split을 요약용, 벡터db용으로 분리했습니다.
- Chunk size를 따로 줄 수 있도록 setting값도 구분 했습니다. 

### 스크린샷(선택)
![image](https://github.com/Team-WeQuiz/wequiz/assets/66217855/7424d7ed-b6de-42cc-aba8-cf1a78581464)

### 비고
해당 풀리퀘에서는 프롬프트길이로 인해 지속적으로 발생하는 에러를 응급처치 해놨습니다.  
그래서 현재 문제 생성 퀄리티가 이상할 수 밖에 없습니다.. (좀만 기다려줘잉)
