### PR TITLE
[BE] 무한 폴링 예외 처리

### DIFF
--- a/chatty-be/src/main/java/com/chatty/chatty/game/exception/GameExceptionType.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/game/exception/GameExceptionType.java
@@ -6,7 +6,8 @@ import com.chatty.chatty.common.exception.Status;
 public enum GameExceptionType implements ExceptionType {
 
     THREAD_INTERRUPTED(Status.SERVER_ERROR, 8001, "폴링 중 스레드가 중단되었습니다"),
-    FAILED_TO_FETCH_DESCRIPTION(Status.SERVER_ERROR, 8002, "10분간의 대기 후 Description을 가져오지 못했습니다");
+    FAILED_TO_FETCH_DESCRIPTION(Status.SERVER_ERROR, 8002, "10분간의 대기 후 Description을 가져오지 못했습니다"),
+    FAILED_TO_FETCH_QUIZ(Status.SERVER_ERROR, 8003, "10분간의 대기 후 Quiz를 가져오지 못했습니다");
 
     private final Status status;
     private final int exceptionCode;

--- a/chatty-be/src/main/java/com/chatty/chatty/game/service/GameService.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/game/service/GameService.java
@@ -1,7 +1,5 @@
 package com.chatty.chatty.game.service;
 
-import static com.chatty.chatty.quizroom.exception.QuizRoomExceptionType.ROOM_NOT_FOUND;
-
 import com.chatty.chatty.game.controller.dto.DescriptionResponse;
 import com.chatty.chatty.game.controller.dto.QuizResponse;
 import com.chatty.chatty.game.controller.dto.ScoreResponse;
@@ -18,7 +16,6 @@ import com.chatty.chatty.game.domain.QuizData;
 import com.chatty.chatty.game.domain.ScoreData;
 import com.chatty.chatty.game.domain.SubmitStatus;
 import com.chatty.chatty.game.domain.UsersSubmitStatus;
-import com.chatty.chatty.game.exception.GameException;
 import com.chatty.chatty.game.repository.AnswerRepository;
 import com.chatty.chatty.game.repository.GameRepository;
 import com.chatty.chatty.game.repository.ScoreRepository;
@@ -29,10 +26,7 @@ import com.chatty.chatty.player.controller.dto.NicknameRequest;
 import com.chatty.chatty.player.controller.dto.PlayersStatusDTO;
 import com.chatty.chatty.player.domain.PlayersStatus;
 import com.chatty.chatty.player.repository.PlayersStatusRepository;
-import com.chatty.chatty.quizroom.entity.Status;
-import com.chatty.chatty.quizroom.exception.QuizRoomException;
 import com.chatty.chatty.quizroom.repository.QuizRoomRepository;
-import com.chatty.chatty.quizroom.service.QuizRoomService;
 import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
@@ -58,7 +52,6 @@ public class GameService {
     private final QuizRoomRepository quizRoomRepository;
     private final DynamoDBService dynamoDBService;
     private final ModelService modelService;
-    private final QuizRoomService quizRoomService;
     private final SimpMessagingTemplate template;
 
     public PlayersStatusDTO joinRoom(Long roomId, Long userId, NicknameRequest request) {
@@ -87,7 +80,7 @@ public class GameService {
     public QuizResponse sendQuiz(Long roomId) {
         QuizData quizData = gameRepository.getQuizData(roomId);
         if (quizData.getQuizQueue().isEmpty() && quizData.getCurrentRound() < quizData.getTotalRound()) {
-            fillQuiz(quizData, roomId);
+            fillQuiz(quizData);
             log.info("Fill: QuizQueue: {}", quizData.getQuizQueue());
         }
         log.info("Send: Quiz: {}", quizData.getQuiz());
@@ -96,28 +89,11 @@ public class GameService {
     }
 
     @Async
-    protected void fillQuiz(QuizData quizData, Long roomId) {
+    protected void fillQuiz(QuizData quizData) {
         Integer currentRound = quizData.getCurrentRound();
         List<Quiz> quizzes;
-        try {
-            quizzes = dynamoDBService.pollQuizzes(quizData.getQuizDocId(), quizData.getTimestamp(),
-                    currentRound, QUIZ_SIZE);
-        } catch (GameException e) {
-            Status status = quizRoomRepository.findById(roomId)
-                    .orElseThrow(() -> new QuizRoomException(ROOM_NOT_FOUND))
-                    .getStatus();
-
-            if (status == Status.READY) {
-                gameRepository.clearQuizData(roomId);
-                playersStatusRepository.clear(roomId);
-                quizRoomRepository.deleteById(roomId);
-            } else if (status == Status.STARTED) {
-                quizRoomService.finishRoom(roomId);
-            }
-            quizRoomService.broadcastUpdatedRoomList();
-            throw e;
-        }
-
+        quizzes = dynamoDBService.pollQuizzes(quizData.getQuizDocId(), quizData.getTimestamp(),
+                currentRound, QUIZ_SIZE);
         List<Quiz> currentQuizzes = quizzes.subList(currentRound * QUIZ_SIZE, (currentRound + 1) * QUIZ_SIZE);
         quizData.fillQuiz(currentQuizzes);
         log.info("filled queue: {}", quizData.getQuizQueue());

--- a/chatty-be/src/main/java/com/chatty/chatty/game/service/GameService.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/game/service/GameService.java
@@ -26,7 +26,6 @@ import com.chatty.chatty.player.controller.dto.NicknameRequest;
 import com.chatty.chatty.player.controller.dto.PlayersStatusDTO;
 import com.chatty.chatty.player.domain.PlayersStatus;
 import com.chatty.chatty.player.repository.PlayersStatusRepository;
-import com.chatty.chatty.quizroom.repository.QuizRoomRepository;
 import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
@@ -49,7 +48,6 @@ public class GameService {
     private final GameRepository gameRepository;
     private final AnswerRepository answerRepository;
     private final ScoreRepository scoreRepository;
-    private final QuizRoomRepository quizRoomRepository;
     private final DynamoDBService dynamoDBService;
     private final ModelService modelService;
     private final SimpMessagingTemplate template;
@@ -91,8 +89,7 @@ public class GameService {
     @Async
     protected void fillQuiz(QuizData quizData) {
         Integer currentRound = quizData.getCurrentRound();
-        List<Quiz> quizzes;
-        quizzes = dynamoDBService.pollQuizzes(quizData.getQuizDocId(), quizData.getTimestamp(),
+        List<Quiz> quizzes = dynamoDBService.pollQuizzes(quizData.getQuizDocId(), quizData.getTimestamp(),
                 currentRound, QUIZ_SIZE);
         List<Quiz> currentQuizzes = quizzes.subList(currentRound * QUIZ_SIZE, (currentRound + 1) * QUIZ_SIZE);
         quizData.fillQuiz(currentQuizzes);

--- a/chatty-be/src/main/java/com/chatty/chatty/quizroom/service/QuizRoomService.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/quizroom/service/QuizRoomService.java
@@ -6,6 +6,7 @@ import static com.chatty.chatty.quizroom.exception.QuizRoomExceptionType.ROOM_NO
 import static com.chatty.chatty.quizroom.exception.QuizRoomExceptionType.ROOM_NOT_STARTED;
 
 import com.chatty.chatty.config.minio.MinioRepository;
+import com.chatty.chatty.game.repository.GameRepository;
 import com.chatty.chatty.game.repository.UserSubmitStatusRepository;
 import com.chatty.chatty.game.service.GameService;
 import com.chatty.chatty.game.service.model.ModelService;
@@ -41,6 +42,7 @@ public class QuizRoomService {
     private static final String BROADCAST_URL = "/sub/rooms?page=%d";
 
     private final QuizRoomRepository quizRoomRepository;
+    private final GameRepository gameRepository;
     private final GameService gameService;
     private final ModelService modelService;
     private final MinioRepository minioRepository;
@@ -137,6 +139,7 @@ public class QuizRoomService {
                     }
                     validateRoomIfStarted(quizRoom.getStatus());
                     updateRoomStatus(roomId, Status.FINISHED);
+                    gameRepository.clearQuizData(roomId);
                     playersStatusRepository.clear(roomId);
                     userSubmitStatusRepository.clear(roomId);
                 }, () -> {


### PR DESCRIPTION
## 개요

- #319 

## 작업사항

- 퀴즈 가져올 때 10분 동안 못 가져오면 에러 날리게 했습니다.
- 대기실일 때랑 게임 시작했을 때 로직 나누려다가 그냥 다 finishroom으로 퉁쳐도 될 거 같아서 구분 안 했습니당

@KRimwoo 
폴링 실패햇을때
1. 대기실일때는 방 폭파
2. 이미 진행한 라운드 있으면 거기까지만 결과 요청

인데 클라에서 **("/{roomId}/end")으로 Delete 요청 먼저 보내주시고**
대기실이면 방 폭파 팝업띄우고 다시 로비로 보내고, 진행 중이면 결과 요청 api 부르는 식으로 하면 될 거 같습니다
