### PR TITLE
[BE] 소셜로그인 및 db 설정 aws secret manager 연동

### DIFF
--- a/chatty-be/src/main/resources/application-local.yml
+++ b/chatty-be/src/main/resources/application-local.yml
@@ -16,12 +16,6 @@ spring:
 social:
   client:
     kakao:
-      client-id: 948b0f6cb65248afcd53e046c4e61145
-      client-secret: KtXGlrkvmLgT8KbvgVzmbvXt15bXXdp6
       redirect-uri: http://localhost:3000/sign-in/kakao/callback
-      grant_type: authorization_code
     google:
-      client-id: 98146529486-md3ri8vfvupsgokf1bup6smaeuj1bbuo.apps.googleusercontent.com
-      client-secret: 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
       redirect-uri: http://localhost:3000/sign-in/google/callback
-      grant_type: authorization_code

--- a/chatty-be/src/main/resources/application-prod.yml
+++ b/chatty-be/src/main/resources/application-prod.yml
@@ -8,21 +8,15 @@ spring:
     hibernate:
       ddl-auto: update
   datasource:
-    url: jdbc:mysql://mysql:3306/wequiz
+    url: ${DATASOURCE_URL}
     driver-class-name: com.mysql.cj.jdbc.Driver
-    username: wequizadmin
-    password: wequizadmin
+    username: ${DATASOURCE_USERNAME}
+    password: ${DATASOURCE_PASSWORD}
 
 # TODO: 소셜 로그인 토큰 재발급 후 수정 필요
 social:
   client:
     kakao:
-      client-id: 948b0f6cb65248afcd53e046c4e61145
-      client-secret: KtXGlrkvmLgT8KbvgVzmbvXt15bXXdp6
-      redirect-uri: http://localhost:3000/sign-in/kakao/callback
-      grant_type: authorization_code
+      redirect-uri: ${KAKAO_REDIRECT_URI}
     google:
-      client-id: 98146529486-md3ri8vfvupsgokf1bup6smaeuj1bbuo.apps.googleusercontent.com
-      client-secret: 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
-      redirect-uri: http://localhost:3000/sign-in/google/callback
-      grant_type: authorization_code
+      redirect-uri: ${GOOGLE_REDIRECT_URI}

--- a/chatty-be/src/main/resources/application-prod.yml
+++ b/chatty-be/src/main/resources/application-prod.yml
@@ -13,7 +13,6 @@ spring:
     username: ${DATASOURCE_USERNAME}
     password: ${DATASOURCE_PASSWORD}
 
-# TODO: 소셜 로그인 토큰 재발급 후 수정 필요
 social:
   client:
     kakao:

--- a/chatty-be/src/main/resources/application.yml
+++ b/chatty-be/src/main/resources/application.yml
@@ -41,3 +41,14 @@ minio:
 
 url:
   ml: ${ML_URL}
+
+social:
+  client:
+    kakao:
+      client-id: ${KAKAO_API_KEY}
+      client-secret: ${KAKAO_API_SECRET}
+      grant_type: authorization_code
+    google:
+      client-id: ${GOOGLE_API_KEY}
+      client-secret: ${GOOGLE_API_SECRET}
+      grant_type: authorization_code


### PR DESCRIPTION
## 개요

- #297 

## 작업사항

- 소셜로그인 및 db 설정 aws secret manager 연동
- 카카오 api key, api secret 재발급
- 구글 api key, api secret 재발급
- 카카오, 구글 redirect uri에 배포환경 추가

