### PR TITLE
[FE] https 환경 테스트, 카카오 로그인 수정

### DIFF
--- a/chatty-fe/.eslintignore
+++ b/chatty-fe/.eslintignore
@@ -1,0 +1,1 @@
+server.js

--- a/chatty-fe/package.json
+++ b/chatty-fe/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "node server.js",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",

--- a/chatty-fe/server.js
+++ b/chatty-fe/server.js
@@ -1,0 +1,40 @@
+const http = require('http');
+const { parse } = require('url');
+const next = require('next');
+
+const https = require('https');
+const fs = require('fs');
+
+const dev = process.env.NODE_ENV !== 'production';
+const app = next({ dev });
+const handle = app.getRequestHandler();
+
+const PORT = 3000;
+
+const httpsOptions = {
+  key: fs.readFileSync('./key.pem'),
+  cert: fs.readFileSync('./cert.pem'),
+};
+
+app.prepare().then(() => {
+  http
+    .createServer((req, res) => {
+      const parsedUrl = parse(req.url, true);
+      handle(req, res, parsedUrl);
+    })
+    .listen(PORT, (err) => {
+      if (err) throw err;
+      console.log(`> Ready on http://localhost:${PORT}`);
+    });
+
+  // https 서버 추가
+  https
+    .createServer(httpsOptions, (req, res) => {
+      const parsedUrl = parse(req.url, true);
+      handle(req, res, parsedUrl);
+    })
+    .listen(PORT + 1, (err) => {
+      if (err) throw err;
+      console.log(`> HTTPS: Ready on https://localhost:${PORT + 1}`);
+    });
+});

--- a/chatty-fe/src/app/(auth)/sign-in/page.tsx
+++ b/chatty-fe/src/app/(auth)/sign-in/page.tsx
@@ -121,7 +121,7 @@ export default function SignIn() {
         integrity="sha384-l+xbElFSnPZ2rOaPrU//2FF5B4LB8FiX5q4fXYTlfcG4PGpMkE1vcL7kNXI6Cci0"
         crossOrigin="anonymous"
         onLoad={() => kakaoInit()}
-        strategy="beforeInteractive"
+        strategy="lazyOnload"
       />
     </div>
   );


### PR DESCRIPTION
## 개요

- #344 

## 작업사항

- https 환경 테스트 가능하게 수정
- 카카오 로그인 수정

### 스크린샷(선택)

설정 방법:

mac 기준

```brew install mkcert```
```mkcert -install```

루트 디렉토리 (chatty-fe)에서:

```mkcert -key-file key.pem -cert-file cert.pem localhost 127.0.0.1 ::1```

하면 루트에 key.pem, cert.pem 파일 만들어짐. 이건 각자 로컬에서 해야됨

npm run dev 실행하면
http://localhost:3000 혹은
https://localhost:3001 에서 사용할 수 있음 끝


