### PR TITLE
[BE] 마이페이지 api 구현

### DIFF
--- a/chatty-be/src/main/java/com/chatty/chatty/auth/config/AuthConfig.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/auth/config/AuthConfig.java
@@ -27,15 +27,12 @@ public class AuthConfig implements WebMvcConfigurer {
         registry.addInterceptor(loginInterceptor());
     }
 
-    /*
-    @AuthUser 어노테이션 사용 시 addPathPattern에 추가해야 함
-     */
     private HandlerInterceptor loginInterceptor() {
         return new PathMatcherInterceptor(loginInterceptor)
                 .excludePathPattern("/**", OPTIONS)
                 .addPathPattern("/user/**", GET)
-                .addPathPattern("/rooms/**", GET, POST);
-//  예시            .addPathPattern("/test", GET, POST);
+                .addPathPattern("/rooms/**", GET, POST)
+                .addPathPattern("/auth/password", POST);
     }
 
     @Override

--- a/chatty-be/src/main/java/com/chatty/chatty/auth/config/AuthConfig.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/auth/config/AuthConfig.java
@@ -30,7 +30,7 @@ public class AuthConfig implements WebMvcConfigurer {
     private HandlerInterceptor loginInterceptor() {
         return new PathMatcherInterceptor(loginInterceptor)
                 .excludePathPattern("/**", OPTIONS)
-                .addPathPattern("/user/**", GET)
+                .addPathPattern("/users/**", GET)
                 .addPathPattern("/rooms/**", GET, POST)
                 .addPathPattern("/auth/password", POST);
     }

--- a/chatty-be/src/main/java/com/chatty/chatty/auth/controller/AuthController.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/auth/controller/AuthController.java
@@ -5,6 +5,8 @@ import com.chatty.chatty.auth.controller.dto.SignInRequest;
 import com.chatty.chatty.auth.controller.dto.SignUpRequest;
 import com.chatty.chatty.auth.controller.dto.TokenResponse;
 import com.chatty.chatty.auth.service.AuthService;
+import com.chatty.chatty.auth.support.AuthUser;
+import com.chatty.chatty.auth.controller.dto.PasswordRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -35,5 +37,11 @@ public class AuthController {
     @PostMapping("/refresh")
     public ResponseEntity<TokenResponse> refresh(@RequestBody RefreshTokenRequest request) {
         return ResponseEntity.status(HttpStatus.OK).body(authService.refresh(request));
+    }
+
+    @PostMapping("/password")
+    public ResponseEntity<Void> changePassword(@AuthUser Long userId, @RequestBody PasswordRequest request) {
+        authService.changePassword(userId, request);
+        return ResponseEntity.ok().build();
     }
 }

--- a/chatty-be/src/main/java/com/chatty/chatty/auth/controller/dto/PasswordRequest.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/auth/controller/dto/PasswordRequest.java
@@ -1,0 +1,8 @@
+package com.chatty.chatty.auth.controller.dto;
+
+public record PasswordRequest(
+        String oldPassword,
+        String newPassword
+) {
+
+}

--- a/chatty-be/src/main/java/com/chatty/chatty/auth/service/AuthService.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/auth/service/AuthService.java
@@ -3,6 +3,7 @@ package com.chatty.chatty.auth.service;
 import static com.chatty.chatty.auth.exception.AuthExceptionType.*;
 import static com.chatty.chatty.user.exception.UserExceptionType.USER_NOT_FOUND;
 
+import com.chatty.chatty.auth.controller.dto.PasswordRequest;
 import com.chatty.chatty.auth.controller.dto.RefreshTokenRequest;
 import com.chatty.chatty.auth.controller.dto.SignInRequest;
 import com.chatty.chatty.auth.controller.dto.SignUpRequest;
@@ -57,6 +58,16 @@ public class AuthService {
                 .accessToken(jwtUtil.createAccessToken(user))
                 .refreshToken(getRefreshToken(user.getId()))
                 .build();
+    }
+
+    @Transactional
+    public void changePassword(Long userId, PasswordRequest request) {
+        User user = findUserById(userId);
+        if (!isPasswordValid(userId, request.oldPassword())) {
+            throw new AuthException(INVALID_PASSWORD);
+        }
+        user.changePassword(encoded(request.newPassword()));
+        userRepository.save(user);
     }
 
     @Transactional

--- a/chatty-be/src/main/java/com/chatty/chatty/game/controller/GameController.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/game/controller/GameController.java
@@ -9,7 +9,6 @@ import com.chatty.chatty.game.controller.dto.SubmitAnswerResponse;
 import com.chatty.chatty.game.service.GameService;
 import com.chatty.chatty.player.controller.dto.NicknameRequest;
 import com.chatty.chatty.player.controller.dto.PlayersStatusDTO;
-import com.chatty.chatty.player.service.PlayerService;
 import com.chatty.chatty.quizroom.service.QuizRoomService;
 import java.time.LocalDateTime;
 import java.util.Objects;
@@ -29,7 +28,6 @@ public class GameController {
 
     private final GameService gameService;
     private final QuizRoomService quizRoomService;
-    private final PlayerService playerService;
     private final SimpMessagingTemplate template;
 
     @MessageMapping("/rooms/{roomId}/chat")
@@ -53,7 +51,6 @@ public class GameController {
     public PlayersStatusDTO joinRoom(@DestinationVariable Long roomId, SimpMessageHeaderAccessor headerAccessor,
             NicknameRequest request) {
         quizRoomService.broadcastUpdatedRoomList();
-        playerService.savePlayer(getUserIdFromHeader(headerAccessor), roomId, request.nickname());
         return gameService.joinRoom(roomId, getUserIdFromHeader(headerAccessor), request);
     }
 
@@ -61,7 +58,6 @@ public class GameController {
     @SendTo("/sub/rooms/{roomId}/status")
     public PlayersStatusDTO leaveRoom(@DestinationVariable Long roomId, SimpMessageHeaderAccessor headerAccessor) {
         quizRoomService.broadcastUpdatedRoomList();
-        playerService.deletePlayer(getUserIdFromHeader(headerAccessor), roomId);
         return gameService.leaveRoom(roomId, getUserIdFromHeader(headerAccessor));
     }
 

--- a/chatty-be/src/main/java/com/chatty/chatty/player/repository/PlayerRepository.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/player/repository/PlayerRepository.java
@@ -8,6 +8,4 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface PlayerRepository extends JpaRepository<Player, Long> {
 
     Page<Player> findByUserIdOrderByCreatedAt(Long userId, Pageable pageable);
-
-    void deleteByUserIdAndQuizRoomId(Long userId, Long roomId);
 }

--- a/chatty-be/src/main/java/com/chatty/chatty/player/repository/PlayerRepository.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/player/repository/PlayerRepository.java
@@ -1,0 +1,2 @@
+package com.chatty.chatty.player.repository;public class PlayerRepository {
+}

--- a/chatty-be/src/main/java/com/chatty/chatty/player/repository/PlayerRepository.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/player/repository/PlayerRepository.java
@@ -1,2 +1,13 @@
-package com.chatty.chatty.player.repository;public class PlayerRepository {
+package com.chatty.chatty.player.repository;
+
+import com.chatty.chatty.player.domain.entity.Player;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PlayerRepository extends JpaRepository<Player, Long> {
+
+    Page<Player> findByUserId(Long userId, Pageable pageable);
+
+    void deleteByUserIdAndQuizRoomId(Long userId, Long roomId);
 }

--- a/chatty-be/src/main/java/com/chatty/chatty/player/repository/PlayerRepository.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/player/repository/PlayerRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PlayerRepository extends JpaRepository<Player, Long> {
 
-    Page<Player> findByUserId(Long userId, Pageable pageable);
+    Page<Player> findByUserIdOrderByCreatedAt(Long userId, Pageable pageable);
 
     void deleteByUserIdAndQuizRoomId(Long userId, Long roomId);
 }

--- a/chatty-be/src/main/java/com/chatty/chatty/player/service/PlayerService.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/player/service/PlayerService.java
@@ -1,0 +1,2 @@
+package com.chatty.chatty.player.service;public class PlayerService {
+}

--- a/chatty-be/src/main/java/com/chatty/chatty/player/service/PlayerService.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/player/service/PlayerService.java
@@ -1,2 +1,40 @@
-package com.chatty.chatty.player.service;public class PlayerService {
+package com.chatty.chatty.player.service;
+
+import static com.chatty.chatty.quizroom.exception.QuizRoomExceptionType.ROOM_NOT_FOUND;
+import static com.chatty.chatty.user.exception.UserExceptionType.USER_NOT_FOUND;
+
+import com.chatty.chatty.player.domain.entity.Player;
+import com.chatty.chatty.player.repository.PlayerRepository;
+import com.chatty.chatty.quizroom.exception.QuizRoomException;
+import com.chatty.chatty.quizroom.repository.QuizRoomRepository;
+import com.chatty.chatty.user.exception.UserException;
+import com.chatty.chatty.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PlayerService {
+
+    private final PlayerRepository playerRepository;
+    private final UserRepository userRepository;
+    private final QuizRoomRepository quizRoomRepository;
+
+    @Transactional
+    public void savePlayer(Long userId, Long roomId, String nickname) {
+        playerRepository.save(
+                Player.builder()
+                        .user(userRepository.findById(userId)
+                                .orElseThrow(() -> new UserException(USER_NOT_FOUND)))
+                        .quizRoom(quizRoomRepository.findById(roomId)
+                                .orElseThrow(() -> new QuizRoomException(ROOM_NOT_FOUND)))
+                        .nickname(nickname)
+                        .build());
+    }
+
+    @Transactional
+    public void deletePlayer(Long userId, Long roomId) {
+        playerRepository.deleteByUserIdAndQuizRoomId(userId, roomId);
+    }
 }

--- a/chatty-be/src/main/java/com/chatty/chatty/player/service/PlayerService.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/player/service/PlayerService.java
@@ -32,9 +32,4 @@ public class PlayerService {
                         .nickname(nickname)
                         .build());
     }
-
-    @Transactional
-    public void deletePlayer(Long userId, Long roomId) {
-        playerRepository.deleteByUserIdAndQuizRoomId(userId, roomId);
-    }
 }

--- a/chatty-be/src/main/java/com/chatty/chatty/user/controller/UserController.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/user/controller/UserController.java
@@ -1,14 +1,21 @@
 package com.chatty.chatty.user.controller;
 
 import com.chatty.chatty.auth.support.AuthUser;
+import com.chatty.chatty.user.controller.dto.ParticipatedQuizRoomDTO;
+import com.chatty.chatty.user.controller.dto.ParticipatedQuizRoomListResponse;
 import com.chatty.chatty.user.controller.dto.UserInfoResponse;
 import com.chatty.chatty.user.service.UserService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@RestController("/user")
+@RestController
+@RequestMapping("/users")
 @RequiredArgsConstructor
 public class UserController {
 
@@ -17,6 +24,12 @@ public class UserController {
     @GetMapping
     public ResponseEntity<UserInfoResponse> getUserInfo(@AuthUser Long userId) {
         return ResponseEntity.ok(userService.getUserInfo(userId));
+    }
+
+    @GetMapping("/participated-rooms")
+    public ResponseEntity<ParticipatedQuizRoomListResponse> getParticipatedQuizRooms(@AuthUser Long userId,
+            @PageableDefault(size = 8) Pageable pageable) {
+        return ResponseEntity.ok(userService.getParticipatedQuizRooms(userId, pageable));
     }
 
 }

--- a/chatty-be/src/main/java/com/chatty/chatty/user/controller/UserController.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/user/controller/UserController.java
@@ -8,20 +8,15 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@RestController
+@RestController("/user")
 @RequiredArgsConstructor
 public class UserController {
 
     private final UserService userService;
 
-
-    @GetMapping("/user")
+    @GetMapping
     public ResponseEntity<UserInfoResponse> getUserInfo(@AuthUser Long userId) {
         return ResponseEntity.ok(userService.getUserInfo(userId));
     }
 
-    @GetMapping("/ping")
-    public ResponseEntity<String> ping() {
-        return ResponseEntity.ok("pong");
-    }
 }

--- a/chatty-be/src/main/java/com/chatty/chatty/user/controller/UserController.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/user/controller/UserController.java
@@ -1,16 +1,13 @@
 package com.chatty.chatty.user.controller;
 
 import com.chatty.chatty.auth.support.AuthUser;
-import com.chatty.chatty.user.controller.dto.ParticipatedQuizRoomDTO;
 import com.chatty.chatty.user.controller.dto.ParticipatedQuizRoomListResponse;
 import com.chatty.chatty.user.controller.dto.UserInfoResponse;
 import com.chatty.chatty.user.service.UserService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -26,10 +23,10 @@ public class UserController {
         return ResponseEntity.ok(userService.getUserInfo(userId));
     }
 
-    @GetMapping("/participated-rooms")
+    @GetMapping("/participated-rooms?page={page}")
     public ResponseEntity<ParticipatedQuizRoomListResponse> getParticipatedQuizRooms(@AuthUser Long userId,
-            @PageableDefault(size = 8) Pageable pageable) {
-        return ResponseEntity.ok(userService.getParticipatedQuizRooms(userId, pageable));
+            @PathVariable Integer page) {
+        return ResponseEntity.ok(userService.getParticipatedQuizRooms(userId, page));
     }
 
 }

--- a/chatty-be/src/main/java/com/chatty/chatty/user/controller/dto/ParticipatedQuizRoomDTO.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/user/controller/dto/ParticipatedQuizRoomDTO.java
@@ -1,0 +1,12 @@
+package com.chatty.chatty.user.controller.dto;
+
+import lombok.Builder;
+
+@Builder
+public record ParticipatedQuizRoomResponse(
+        Long roomId,
+        String roomName,
+        String roomDescription
+) {
+
+}

--- a/chatty-be/src/main/java/com/chatty/chatty/user/controller/dto/ParticipatedQuizRoomDTO.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/user/controller/dto/ParticipatedQuizRoomDTO.java
@@ -3,10 +3,10 @@ package com.chatty.chatty.user.controller.dto;
 import lombok.Builder;
 
 @Builder
-public record ParticipatedQuizRoomResponse(
+public record ParticipatedQuizRoomDTO(
         Long roomId,
-        String roomName,
-        String roomDescription
+        String name,
+        String description
 ) {
 
 }

--- a/chatty-be/src/main/java/com/chatty/chatty/user/controller/dto/ParticipatedQuizRoomListResponse.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/user/controller/dto/ParticipatedQuizRoomListResponse.java
@@ -1,0 +1,2 @@
+package com.chatty.chatty.user.controller.dto;public record ParticipatedQuizRoomListResponse() {
+}

--- a/chatty-be/src/main/java/com/chatty/chatty/user/controller/dto/ParticipatedQuizRoomListResponse.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/user/controller/dto/ParticipatedQuizRoomListResponse.java
@@ -1,2 +1,13 @@
-package com.chatty.chatty.user.controller.dto;public record ParticipatedQuizRoomListResponse() {
+package com.chatty.chatty.user.controller.dto;
+
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record ParticipatedQuizRoomListResponse(
+        Integer totalPages,
+        Integer currentPage,
+        List<ParticipatedQuizRoomDTO> rooms
+) {
+
 }

--- a/chatty-be/src/main/java/com/chatty/chatty/user/entity/User.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/user/entity/User.java
@@ -51,4 +51,8 @@ public class User extends BaseEntity {
     @Column(nullable = false)
     @Builder.Default
     private Provider loginType = Provider.NORMAL;
+
+    public void changePassword(String password) {
+        this.password = password;
+    }
 }

--- a/chatty-be/src/main/java/com/chatty/chatty/user/service/UserService.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/user/service/UserService.java
@@ -12,6 +12,7 @@ import com.chatty.chatty.user.exception.UserException;
 import com.chatty.chatty.user.repository.UserRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.data.domain.Page;
@@ -19,6 +20,8 @@ import org.springframework.data.domain.Page;
 @Service
 @RequiredArgsConstructor
 public class UserService {
+
+    private static final Integer DEFAULT_PAGE_SIZE = 8;
 
     private final UserRepository userRepository;
     private final PlayerRepository playerRepository;
@@ -35,8 +38,9 @@ public class UserService {
                 .orElseThrow(() -> new UserException(USER_NOT_FOUND));
     }
 
-    public ParticipatedQuizRoomListResponse getParticipatedQuizRooms(Long userId, Pageable pageable) {
-        Page<Player> players = playerRepository.findByUserId(userId, pageable);
+    public ParticipatedQuizRoomListResponse getParticipatedQuizRooms(Long userId, Integer page) {
+        PageRequest pageRequest = PageRequest.of(page - 1, DEFAULT_PAGE_SIZE);
+        Page<Player> players = playerRepository.findByUserIdOrderByCreatedAt(userId, pageRequest);
         List<ParticipatedQuizRoomDTO> roomDTOs = players.map(player -> ParticipatedQuizRoomDTO.builder()
                 .roomId(player.getQuizRoom().getId())
                 .name(player.getQuizRoom().getName())

--- a/chatty-be/src/main/java/com/chatty/chatty/user/service/UserService.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/user/service/UserService.java
@@ -2,17 +2,26 @@ package com.chatty.chatty.user.service;
 
 import static com.chatty.chatty.user.exception.UserExceptionType.USER_NOT_FOUND;
 
+import com.chatty.chatty.player.domain.entity.Player;
+import com.chatty.chatty.player.repository.PlayerRepository;
+import com.chatty.chatty.quizroom.entity.QuizRoom;
+import com.chatty.chatty.user.controller.dto.ParticipatedQuizRoomDTO;
+import com.chatty.chatty.user.controller.dto.ParticipatedQuizRoomListResponse;
 import com.chatty.chatty.user.controller.dto.UserInfoResponse;
 import com.chatty.chatty.user.exception.UserException;
 import com.chatty.chatty.user.repository.UserRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.data.domain.Page;
 
 @Service
 @RequiredArgsConstructor
 public class UserService {
 
     private final UserRepository userRepository;
+    private final PlayerRepository playerRepository;
 
     public UserInfoResponse getUserInfo(Long userId) {
         return userRepository.findById(userId)
@@ -24,5 +33,20 @@ public class UserService {
                         .loginType(user.getLoginType())
                         .build())
                 .orElseThrow(() -> new UserException(USER_NOT_FOUND));
+    }
+
+    public ParticipatedQuizRoomListResponse getParticipatedQuizRooms(Long userId, Pageable pageable) {
+        Page<Player> players = playerRepository.findByUserId(userId, pageable);
+        List<ParticipatedQuizRoomDTO> roomDTOs = players.map(player -> ParticipatedQuizRoomDTO.builder()
+                .roomId(player.getQuizRoom().getId())
+                .name(player.getQuizRoom().getName())
+                .description(player.getQuizRoom().getDescription())
+                .build()).toList();
+
+        return ParticipatedQuizRoomListResponse.builder()
+                .totalPages(players.getTotalPages())
+                .currentPage(players.getNumber())
+                .rooms(roomDTOs)
+                .build();
     }
 }

--- a/chatty-be/src/main/java/com/chatty/chatty/user/service/UserService.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/user/service/UserService.java
@@ -48,7 +48,7 @@ public class UserService {
                 .build()).toList();
 
         return ParticipatedQuizRoomListResponse.builder()
-                .totalPages(players.getTotalPages())
+                .totalPages(players.getTotalPages() + 1)
                 .currentPage(players.getNumber())
                 .rooms(roomDTOs)
                 .build();

--- a/chatty-be/src/main/resources/application-prod.yml
+++ b/chatty-be/src/main/resources/application-prod.yml
@@ -6,7 +6,7 @@ spring:
         show_sql: false
         dialect: org.hibernate.dialect.MySQLDialect
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
   datasource:
     url: ${DATASOURCE_URL}
     driver-class-name: com.mysql.cj.jdbc.Driver


### PR DESCRIPTION
## 개요

- #342 

## 작업사항

- `/user` ->`/users` 로 맵핑 변경
- 배포환경 db 초기화를 위해 yml 파일 db create로 변경
- 퀴즈방 입퇴실 시 Player 객체를 db에 저장 혹은 삭제 하도록 구현
- 마이페이지에서 참여한 퀴즈방 조회할 수 있는 api 구현 (페이지네이션 포함)
  - /users/participated-rooms?page={page}
  - page는 1부터 시작
  -
 ```
{
    "totalPages": 2
    "currentPage": 1,
    "rooms": [
        {
            "roomId" : 1,
            "name": "방이름",
            "description": "설명"
        }
        {
            "roomId" : 2,
            "name": "방이름",
            "description": "설명"
        }
    ]
}
```
### 스크린샷(선택)
