### PR TITLE
[BE] 플레이어 수 업뎃 되기 전에 답안큐 초기화 되는 문제 해결

### DIFF
--- a/chatty-be/src/main/java/com/chatty/chatty/game/controller/dto/QuizReadyResponse.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/game/controller/dto/QuizReadyResponse.java
@@ -1,0 +1,9 @@
+package com.chatty.chatty.game.controller.dto;
+
+import lombok.Builder;
+
+@Builder
+public record QuizReadyResponse(
+        Boolean isReady
+) {
+}

--- a/chatty-be/src/main/java/com/chatty/chatty/game/service/GameService.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/game/service/GameService.java
@@ -91,8 +91,7 @@ public class GameService {
         return buildQuizResponse(quizData);
     }
 
-    @Async
-    protected void fillQuiz(QuizData quizData) {
+    private void fillQuiz(QuizData quizData) {
         Integer currentRound = quizData.getCurrentRound();
         List<QuizDTO> quizDTOList = dynamoDBService.pollQuizzes(quizData.getQuizDocId(), quizData.getTimestamp(),
                 currentRound, QUIZ_SIZE);

--- a/chatty-be/src/main/java/com/chatty/chatty/game/service/GameService.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/game/service/GameService.java
@@ -89,6 +89,7 @@ public class GameService {
         QuizData quizData = gameRepository.getQuizData(roomId);
         initQuiz(quizData);
         log.info("Send: Quiz: {}", gameRepository.getQuizData(roomId).getQuiz());
+        answerRepository.getAnswerData(roomId);
         return buildQuizResponse(quizData);
     }
 

--- a/chatty-be/src/main/java/com/chatty/chatty/quizroom/service/QuizRoomService.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/quizroom/service/QuizRoomService.java
@@ -89,6 +89,7 @@ public class QuizRoomService {
                 .orElseThrow(() -> new QuizRoomException(ROOM_NOT_FOUND));
         validateRoomIfReady(quizRoom.getStatus());
         gameService.sendDescription(quizRoom.getId(), userId);
+        gameService.sendQuizReady(quizRoom.getId(), userId);
 
         return RoomDetailResponse.builder()
                 .roomId(quizRoom.getId())

--- a/chatty-be/src/main/java/com/chatty/chatty/quizroom/service/QuizRoomService.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/quizroom/service/QuizRoomService.java
@@ -175,13 +175,13 @@ public class QuizRoomService {
                     if (quizRoom.getStatus() == Status.STARTED) {
                         return;
                     }
+                    validateRoomIfReady(quizRoom.getStatus());
+                    updateRoomStatus(quizRoom, Status.STARTED);
+                    savePlayersCount(quizRoom);
                     PlayersStatus players = playersStatusRepository.findByRoomId(roomId).get();
                     players.playerStatusSet()
                             .forEach(player -> playerService.savePlayer(player.userId(), roomId, player.nickname()));
                     userSubmitStatusRepository.init(players, roomId);
-                    savePlayersCount(quizRoom);
-                    validateRoomIfReady(quizRoom.getStatus());
-                    updateRoomStatus(roomId, Status.STARTED);
                 }, () -> {
                     throw new QuizRoomException(ROOM_NOT_FOUND);
                 });
@@ -196,7 +196,7 @@ public class QuizRoomService {
                         return;
                     }
                     validateRoomIfStarted(quizRoom.getStatus());
-                    updateRoomStatus(roomId, Status.FINISHED);
+                    updateRoomStatus(quizRoom, Status.FINISHED);
                     gameRepository.clearQuizData(roomId);
                     playersStatusRepository.clear(roomId);
                     userSubmitStatusRepository.clear(roomId);
@@ -210,8 +210,9 @@ public class QuizRoomService {
         quizRoomRepository.save(quizRoom);
     }
 
-    private void updateRoomStatus(Long roomId, Status status) {
-        quizRoomRepository.updateStatusById(roomId, status);
+    private void updateRoomStatus(QuizRoom quizRoom, Status status) {
+        quizRoom.setStatus(status);
+        quizRoomRepository.save(quizRoom);
     }
 
     public void broadcastUpdatedRoomList() {


### PR DESCRIPTION
## 개요

- #378 

## 작업사항

- 클라이언트에서 sendQuiz 후 start를 호출하여 갱신된 playerNumber가 반영이 안 되고 있었음.
- 대기실 접속 요청이 있을 때 퀴즈 큐를 초기화하게 하여 Description과 같은 방식으로 퀴즈 준비 상태를 소켓으로 보내주게 변경함
- 구독 경로: `/user/{userId}/queue/rooms/{roomId}/quizReady`
- 대기실 접속 요청에서 요약과 퀴즈 레디 다 처리합니다. 경로 구독만 추가하고 따로 추가로 요청할 건 없습니다~!

### 스크린샷(선택)
