### PR TITLE
[BE] 퀴즈 삭제 후 다음 퀴즈 넘기게 수정

### DIFF
--- a/chatty-be/src/main/java/com/chatty/chatty/game/domain/QuizData.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/game/domain/QuizData.java
@@ -18,6 +18,7 @@ public class QuizData {
     private final String timestamp;
     private final Integer totalRound;
     private Integer currentRound;
+    private Integer nextQuizNumber;
 
     public QuizDTO getQuiz() {
         return quizDTOQueue.peek();
@@ -28,7 +29,11 @@ public class QuizData {
         this.currentRound++;
     }
 
-    public QuizDTO removeQuiz() {
-        return quizDTOQueue.poll();
+    public void removeQuiz() {
+        quizDTOQueue.poll();
+    }
+
+    public void increaseNextQuizNumber() {
+        this.nextQuizNumber++;
     }
 }

--- a/chatty-be/src/main/java/com/chatty/chatty/game/exception/GameExceptionType.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/game/exception/GameExceptionType.java
@@ -7,7 +7,8 @@ public enum GameExceptionType implements ExceptionType {
 
     THREAD_INTERRUPTED(Status.SERVER_ERROR, 8001, "폴링 중 스레드가 중단되었습니다"),
     FAILED_TO_FETCH_DESCRIPTION(Status.SERVER_ERROR, 8002, "10분간의 대기 후 Description을 가져오지 못했습니다"),
-    FAILED_TO_FETCH_QUIZ(Status.SERVER_ERROR, 8003, "10분간의 대기 후 Quiz를 가져오지 못했습니다");
+    FAILED_TO_FETCH_QUIZ(Status.SERVER_ERROR, 8003, "10분간의 대기 후 Quiz를 가져오지 못했습니다"),
+    FAILED_TO_SUBMIT_ANSWER(Status.BAD_REQUEST, 8004, "퀴즈 데이터가 없어 답안을 제출할 수 없습니다.");
 
     private final Status status;
     private final int exceptionCode;

--- a/chatty-be/src/main/java/com/chatty/chatty/game/service/GameService.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/game/service/GameService.java
@@ -88,8 +88,12 @@ public class GameService {
     public QuizResponse sendQuiz(Long roomId) {
         QuizData quizData = gameRepository.getQuizData(roomId);
         initQuiz(quizData);
-        log.info("Send: Quiz: {}", gameRepository.getQuizData(roomId).getQuiz());
-        answerRepository.getAnswerData(roomId);
+        QuizDTO peekedQuiz = quizData.getQuiz();
+        while (!peekedQuiz.questionNumber().equals(quizData.getNextQuizNumber())) {
+            peekedQuiz = quizData.getQuiz();
+        }
+        log.info("Send: Quiz: {}", peekedQuiz);
+        answerRepository.initAnswerDataIfAbsent(roomId);
         return buildQuizResponse(quizData);
     }
 
@@ -102,10 +106,9 @@ public class GameService {
         log.info("filled queue: {}", quizData.getQuizDTOQueue());
     }
 
-    public QuizDTO removeQuiz(Long roomId) {
-        QuizData quizData = gameRepository.getQuizData(roomId);
-        log.info("Remove: QuizQueue: {}", quizData.getQuizDTOQueue());
-        return quizData.removeQuiz();
+    public void removeQuiz(QuizData quizData) {
+        log.info("Remove: removedQuiz: {}", quizData.getQuizDTOQueue().peek());
+        quizData.removeQuiz();
     }
 
     /*
@@ -156,24 +159,32 @@ public class GameService {
     }
 
     public SubmitAnswerResponse addPlayerAnswer(Long roomId, SubmitAnswerRequest request, Long userId) {
+        QuizData quizData = gameRepository.getQuizData(roomId);
+        // 플레이어 답안 맵에 답안 추가
         AnswerData answerData = answerRepository.getAnswerData(roomId);
+        if (!request.quizNumber().equals(quizData.getNextQuizNumber() - 1)) {
+            request = new SubmitAnswerRequest(request.quizNumber(), "");
+        }
         Boolean submitStatus = answerData.addAnswer(userId, request);
         log.info("Add Answer: PlayerAnswers: {}", answerData.getPlayerAnswers());
+
+        // 플레이어 제출 현황 갱신
         UsersSubmitStatus usersSubmitStatus = userSubmitStatusRepository.submit(roomId, userId);
+
         long submitCount = usersSubmitStatus.usersSubmitStatus().stream()
                 .filter(UserSubmitStatus::isSolved)
                 .count();
-
+        // 전체 제출일 때 처리
         if (submitCount == usersSubmitStatus.usersSubmitStatus().size()) {
             log.info("Answer All Submitted: PlayerAnswers: {}", answerData.getPlayerAnswers());
-            QuizDTO removedQuiz = removeQuiz(roomId);
-
+            // ML에 플레이어들 답안 넘겨서 채점 요청 후 채점 문서 id 저장
+            QuizDTO solvedQuiz = quizData.getQuiz();
             QuizRoom quizRoom = quizRoomRepository.findById(roomId).get();
             MarkResponse markResponse = modelService.requestMark(MarkRequest.builder()
                     .id(quizRoom.getQuizDocId())
-                    .quiz_id(removedQuiz.id())
+                    .quiz_id(solvedQuiz.id())
                     .question_number(answerData.getQuizNum())
-                    .correct(removedQuiz.correct())
+                    .correct(solvedQuiz.correct())
                     .answers(getAnswers(answerData.getPlayerAnswers()))
                     .build());
             if (quizRoom.getMarkDocId() == null) {
@@ -181,13 +192,18 @@ public class GameService {
                 quizRoomRepository.save(quizRoom);
             }
 
+            // 점수 갱신
             ScoreData scoreData = scoreRepository.getScoreData(roomId);
             scoreData.addScore(answerData, markResponse.answers());
             log.info("ScoreMap: {}", scoreData.getPlayersScore());
 
+            // 플레이어 제출 상태, 답안 맵 초기화
             PlayersStatus players = playersStatusRepository.findByRoomId(roomId).get();
             userSubmitStatusRepository.init(players, roomId);
             answerRepository.clearAnswerData(roomId);
+
+            // 퀴즈 큐에서 직전 문제 삭제
+            removeQuiz(quizData);
         }
         return SubmitAnswerResponse.builder()
                 .isMajority(submitStatus)


### PR DESCRIPTION
## 개요

- #392 

## 작업사항

- 소켓 응답으로 보내려는 퀴즈가 보내야하는 퀴즈 번호와 일치할 때까지 while문을 돌립니다.
- 보내야하는 퀴즈 번호(nextQuizNumber)는 퀴즈를 보내자마자 업데이트하고,
퀴즈 큐에서 이전 퀴즈를 지우는 작업은 전체 제출 시 로직 맨 마지막에 수행하여
이전 퀴즈를 지운 후 다음 퀴즈가 넘어가게 했습니다.
- 플레이어 답안을 받았을 때, 받은 답안의 퀴즈 번호가 현재 퀴즈 번호와 다르면 답안을 ""로 변경합니다.

### 스크린샷(선택)
