### PR TITLE
[ML] 채점, 퀴즈 디비 스키마, 필드명 수정

### DIFF
--- a/model/app/data/generator.py
+++ b/model/app/data/generator.py
@@ -107,7 +107,7 @@ class Marker():
     def __init__(self):
         self.marker_chain = MarkChain()
     
-    async def mark(self, answer, user):
+    async def mark(self, answer, user, type):
         if user.strip() == '':
             return False
         else:

--- a/model/app/schema.py
+++ b/model/app/schema.py
@@ -4,15 +4,17 @@ from typing import List
 class GenerateRequest(BaseModel):
     timestamp: str
     user_id: int
-    numOfQuiz: int
+    num_of_quiz: int
 
 class Answer(BaseModel):
     user_id: int # user_id
-    user: str # 유저가 작성한 답안
+    user_answer: str # 유저가 작성한 답안
 
 class MarkRequest(BaseModel):
-    id: str  # quiz_set id
-    quiz_id: str # quiz_id
-    question_number: int # 퀴즈방 내에서의 quiz number
-    correct: str # 답안
-    answers: List[Answer]
+    id: str  # **quiz_set** id
+    timestamp: str # quiz방 생성 시간
+    quiz_id: str 
+    quiz_num: int
+    quiz_type: str
+    correct_answer: str  # 답안
+    submit_answers: List[Answer]  # 제출 답안


### PR DESCRIPTION
## 개요

- resolves #468 

## 작업사항

- 퀴즈요청 필드명 수정
  - numOfQuiz -> num_of_quiz
- 채점요청 스키마 및 필드명 수정
  - timestamp 추가
  - question_number -> quiz_num
  - quiz_type 추가
  - correct -> correct_answer
  - answers -> submit_answers
  - answer -> user_answer
(빼먹은게 있을 수 있으니 노션 DTO 반드시 확인 바랍니다)
- quiz db key: id
- mark db key: id, timestamp

### 스크린샷(선택)
![image](https://github.com/Team-WeQuiz/wequiz/assets/66217855/0e97ddb8-844d-476b-9535-97cb0558ba54)
![image](https://github.com/Team-WeQuiz/wequiz/assets/66217855/4281c810-9b68-4651-978b-4d71c78c8b0e)
![image](https://github.com/Team-WeQuiz/wequiz/assets/66217855/a16aa424-3c15-4ca8-86d0-fdf77cffd5a1)

