### PR TITLE
[BE] 0초에서 걸리는 시간 줄이기

### DIFF
--- a/chatty-be/src/main/java/com/chatty/chatty/game/domain/AnswerData.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/game/domain/AnswerData.java
@@ -50,4 +50,25 @@ public class AnswerData {
         }
         return false;
     }
+
+    public AnswerData clone() {
+        AnswerData clonedAnswerData = AnswerData.builder()
+                .playerNum(playerNum)
+                .majorityNum(majorityNum)
+                .quizId(quizId)
+                .quizNum(quizNum)
+                .quizType(quizType)
+                .correct(correct)
+                .startedTime(startedTime)
+                .build();
+        
+        for (Map.Entry<Long, PlayerAnswerData> entry : playerAnswers.entrySet()) {
+            PlayerAnswerData clonedData = PlayerAnswerData.builder()
+                    .playerAnswer(entry.getValue().playerAnswer())
+                    .submittedTime(entry.getValue().submittedTime())
+                    .build();
+            clonedAnswerData.playerAnswers.put(entry.getKey(), clonedData);
+        }
+        return clonedAnswerData;
+    }
 }

--- a/chatty-be/src/main/java/com/chatty/chatty/game/domain/ScoreData.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/game/domain/ScoreData.java
@@ -10,8 +10,10 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 
 @Getter
+@Slf4j
 public class ScoreData {
 
     @Getter

--- a/chatty-be/src/main/java/com/chatty/chatty/game/repository/AnswerRepository.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/game/repository/AnswerRepository.java
@@ -32,10 +32,11 @@ public class AnswerRepository {
         QuizRoom quizRoom = quizRoomRepository.findById(roomId)
                 .orElseThrow(() -> new QuizRoomException(ROOM_NOT_FOUND));
         QuizData quizData = gameRepository.getQuizData(roomId);
+        int majorityNum = (quizRoom.getPlayerNum() == 2) ? 1 : (quizRoom.getPlayerNum() / 2 + 1);
 
         return AnswerData.builder()
                 .playerNum(quizRoom.getPlayerNum())
-                .majorityNum(quizRoom.getPlayerNum() / 2 + 1)
+                .majorityNum(majorityNum)
                 .quizId(quizData.getQuiz().id())
                 .quizNum(quizData.getQuiz().questionNumber())
                 .quizType(quizData.getQuiz().type())

--- a/chatty-be/src/main/java/com/chatty/chatty/game/repository/AnswerRepository.java
+++ b/chatty-be/src/main/java/com/chatty/chatty/game/repository/AnswerRepository.java
@@ -35,7 +35,7 @@ public class AnswerRepository {
 
         return AnswerData.builder()
                 .playerNum(quizRoom.getPlayerNum())
-                .majorityNum((quizRoom.getPlayerNum() + 1) / 2)
+                .majorityNum(quizRoom.getPlayerNum() / 2 + 1)
                 .quizId(quizData.getQuiz().id())
                 .quizNum(quizData.getQuiz().questionNumber())
                 .quizType(quizData.getQuiz().type())


### PR DESCRIPTION
## 개요

- #455 

## 작업사항

- 문제가 넘어갈 때 라운드별 마지막 문제면 점수 계산을 마친 후 -1 카운트를 보내고
- 라운드별 마지막 문제가 아니면 -1 카운트를 보내고 서버에서 따로 채점 요청과 점수 계산을 하여
- 0초에서 문제가 넘어갈 때 걸리는 시간을 줄였습니다.
- 라운드별 마지막 문제만 score 모달이 뜨기까지 시간이 조금 걸리고 다른 건 0초 뜨고 1초 뒤에 바로 다음 문제로 넘어갑니당

### 스크린샷(선택)
